### PR TITLE
Fix sampler address mode 'clamp_to_border'

### DIFF
--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -5079,7 +5079,7 @@ namespace avk
 			addressMode = vk::SamplerAddressMode::eMirrorClampToEdge;
 			break;
 		case border_handling_mode::clamp_to_border:
-			addressMode = vk::SamplerAddressMode::eClampToEdge;
+			addressMode = vk::SamplerAddressMode::eClampToBorder;
 			break;
 		case border_handling_mode::repeat:
 			addressMode = vk::SamplerAddressMode::eRepeat;


### PR DESCRIPTION
This was mistakenly set to clamp to edge.