### PR TITLE
Added casts to avoid compiler warnings

### DIFF
--- a/include/avk/command_buffer.hpp
+++ b/include/avk/command_buffer.hpp
@@ -184,7 +184,7 @@ namespace avk
 			}
 			
 			handle().bindIndexBuffer(aIndexBuffer.handle(), 0u, indexType);
-			handle().drawIndexed(indexMeta.num_elements(), aNumberOfInstances, aFirstIndex, aVertexOffset, aFirstInstance);
+			handle().drawIndexed(static_cast<uint32_t>(indexMeta.num_elements()), aNumberOfInstances, aFirstIndex, aVertexOffset, aFirstInstance);
 		}
 		
 		/**	Perform an indexed draw call with vertex buffer bindings starting at BUFFER-BINDING #0 top to the number of total vertex buffers passed -1.

--- a/include/avk/shader_info.hpp
+++ b/include/avk/shader_info.hpp
@@ -61,7 +61,7 @@ namespace avk
 			// copy data:
 			memcpy(data.data() + currentSize, &aValue, insertSize);
 			// make entry:
-			entries.emplace_back(aConstantId, currentSize, insertSize);
+			entries.emplace_back(aConstantId, static_cast<uint32_t>(currentSize), insertSize);
 
 			return *this;
 		}


### PR DESCRIPTION
Implicit type conversion warnings were emitted when using
'shader_info::set_specialization_constant' and
'command_buffer_t::draw_indexed'