### PR TITLE
Added `fill_partially` and overload for `draw_vertices`

### DIFF
--- a/include/avk/buffer.hpp
+++ b/include/avk/buffer.hpp
@@ -184,11 +184,11 @@ namespace avk
 		*
 		*  @param aDataPtr			Pointer to the data to copy to the buffer
 		*  @param aDataSizeInBytes	Number of bytes to copy
-		*  @param aOffset			Offset from the start of the buffer (data will be copied to bufferstart + aOffset)
+		*  @param aOffsetInBytes	Offset from the start of the buffer (data will be copied to bufferstart + aOffset)
 		*  @param aMetaDataIndex	Index of the buffer metadata to use (for size validation only)
 		*  @param aSyncHandler		Synchronization handler for the copy operation
 		*/
-		std::optional<command_buffer> fill_partially(const void* aDataPtr, size_t aDataSizeInBytes, size_t aOffset, size_t aMetaDataIndex, sync aSyncHandler);
+		std::optional<command_buffer> fill(const void* aDataPtr, size_t aMetaDataIndex, size_t aOffsetInBytes, size_t aDataSizeInBytes, sync aSyncHandler);
 
 		/** Read data from buffer back to the CPU-side.
 		 */

--- a/include/avk/buffer.hpp
+++ b/include/avk/buffer.hpp
@@ -173,9 +173,22 @@ namespace avk
 		auto as_storage_buffer() const { return get_buffer_descriptor<storage_buffer_meta>(); }
 
 		/** Fill buffer with data.
+		 *  The buffer's size is determined from its metadata
+		 *  @param aDataPtr			Pointer to the data to copy to the buffer. MUST point to at least enough data to fill the buffer entirely.
+		 *  @param aMetaDataIndex	Index of the buffer metadata to use (for determining the buffer size)
+		 *  @param aSyncHandler		Synchronization handler for the copy operation
 		 */
 		std::optional<command_buffer> fill(const void* aDataPtr, size_t aMetaDataIndex, sync aSyncHandler);
-		std::optional<command_buffer> fill_partially(const void* aDataPtr, size_t aDataSizeInBytes, sync aSyncHandler);
+
+		/** Fill buffer partially with data.
+		*
+		*  @param aDataPtr			Pointer to the data to copy to the buffer
+		*  @param aDataSizeInBytes	Number of bytes to copy
+		*  @param aOffset			Offset from the start of the buffer (data will be copied to bufferstart + aOffset)
+		*  @param aMetaDataIndex	Index of the buffer metadata to use (for size validation only)
+		*  @param aSyncHandler		Synchronization handler for the copy operation
+		*/
+		std::optional<command_buffer> fill_partially(const void* aDataPtr, size_t aDataSizeInBytes, size_t aOffset, size_t aMetaDataIndex, sync aSyncHandler);
 
 		/** Read data from buffer back to the CPU-side.
 		 */

--- a/include/avk/buffer.hpp
+++ b/include/avk/buffer.hpp
@@ -175,6 +175,7 @@ namespace avk
 		/** Fill buffer with data.
 		 */
 		std::optional<command_buffer> fill(const void* aDataPtr, size_t aMetaDataIndex, sync aSyncHandler);
+		std::optional<command_buffer> fill_partially(const void* aDataPtr, size_t aDataSizeInBytes, sync aSyncHandler);
 
 		/** Read data from buffer back to the CPU-side.
 		 */

--- a/include/avk/command_buffer.hpp
+++ b/include/avk/command_buffer.hpp
@@ -127,6 +127,7 @@ namespace avk
 		/**	Draw vertices with vertex buffer bindings starting at BUFFER-BINDING #0 top to the number of total buffers passed -1.
 		 *	"BUFFER-BINDING" means that it corresponds to the binding specified in `input_binding_location_data::from_buffer_at_binding`.
 		 *	There can be no gaps between buffer bindings.
+		 *  @param  aNumberOfVertices   Number of vertices to draw
 		 *	@param	aVertexBuffer		There must be at least one vertex buffer, the meta data of which will be used
 		 *								to get the number of vertices to draw.
 		 *	@param	aNumberOfInstances	Number of instances to draw
@@ -135,17 +136,35 @@ namespace avk
 		 *	@param	aFurtherBuffers		And optionally, there can be further vertex buffers.
 		 */
 		template <typename... Bfrs>
-		void draw_vertices(uint32_t aNumberOfInstances, uint32_t aFirstVertex, uint32_t aFirstInstance, const buffer_t& aVertexBuffer, const Bfrs&... aFurtherBuffers)
+		void draw_vertices(uint32_t aNumberOfVertices, uint32_t aNumberOfInstances, uint32_t aFirstVertex, uint32_t aFirstInstance, const buffer_t& aVertexBuffer, const Bfrs&... aFurtherBuffers)
 		{
 			handle().bindVertexBuffers(0u, { aVertexBuffer.handle(), aFurtherBuffers.handle() ... }, { vk::DeviceSize{0}, ((void)aFurtherBuffers, vk::DeviceSize{0}) ... });
 			//																									Make use of the discarding behavior of the comma operator ^, see: https://stackoverflow.com/a/61098748/387023
+			handle().draw(aNumberOfVertices, aNumberOfInstances, aFirstVertex, aFirstInstance);                      
+		}
+
+		/**	Draw vertices with vertex buffer bindings starting at BUFFER-BINDING #0 top to the number of total buffers passed -1.
+		*	"BUFFER-BINDING" means that it corresponds to the binding specified in `input_binding_location_data::from_buffer_at_binding`.
+		*	There can be no gaps between buffer bindings.
+		*   Number of vertices is automatically determined from the vertex buffer
+		*	@param	aVertexBuffer		There must be at least one vertex buffer, the meta data of which will be used
+		*								to get the number of vertices to draw.
+		*	@param	aNumberOfInstances	Number of instances to draw
+		*	@param	aFirstVertex		Offset to the first vertex
+		*	@param	aFirstInstance		The ID of the first instance
+		*	@param	aFurtherBuffers		And optionally, there can be further vertex buffers.
+		*/
+		template <typename... Bfrs>
+		void draw_vertices(uint32_t aNumberOfInstances, uint32_t aFirstVertex, uint32_t aFirstInstance, const buffer_t& aVertexBuffer, const Bfrs&... aFurtherBuffers)
+		{
 			const auto& vertexMeta = aVertexBuffer.template meta<avk::vertex_buffer_meta>();
-			handle().draw(vertexMeta.num_elements(), aNumberOfInstances, aFirstVertex, aFirstInstance);                      
+			draw_vertices(static_cast<uint32_t>(vertexMeta.num_elements()), aNumberOfInstances, aFirstVertex, aFirstInstance, aVertexBuffer, aFurtherBuffers...);
 		}
 
 		/**	Draw vertices with vertex buffer bindings starting at BUFFER-BINDING #0 top to the number of total buffers passed -1.
 		 *	"BUFFER-BINDING" means that it corresponds to the binding specified in `input_binding_location_data::from_buffer_at_binding`.
 		 *	There can be no gaps between buffer bindings.
+		 *  Number of vertices is automatically determined from the vertex buffer
 		 *	Number of instances is set to 1.
 		 *	Offset to the first vertex is set to 0.
 		 *	The ID of the first instance is set to 0.

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -2314,11 +2314,17 @@ namespace avk
 		
 		return result;
 	}
-	
+
 	std::optional<command_buffer> buffer_t::fill(const void* aDataPtr, size_t aMetaDataIndex, sync aSyncHandler)
 	{
 		auto metaData = meta_at_index<buffer_meta>(aMetaDataIndex);
 		auto bufferSize = static_cast<vk::DeviceSize>(metaData.total_size());
+		return fill_partially(aDataPtr, bufferSize, std::move(aSyncHandler));
+	}
+
+	std::optional<command_buffer> buffer_t::fill_partially(const void* aDataPtr, size_t aDataSizeInBytes, sync aSyncHandler)
+	{
+		auto bufferSize = static_cast<vk::DeviceSize>(aDataSizeInBytes);
 		auto memProps = memory_properties();
 
 		// #1: Is our memory accessible from the CPU-SIDE? 

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -2362,7 +2362,8 @@ namespace avk
 
 			// Operation:
 			auto copyRegion = vk::BufferCopy{}
-				.setSrcOffset(0u) // TODO: Support different offsets or whatever?!
+				.setSrcOffset(0u)
+
 				.setDstOffset(static_cast<uint32_t>(aOffsetInBytes))
 				.setSize(dataSize);
 			commandBuffer.handle().copyBuffer(stagingBuffer->handle(), handle(), { copyRegion });


### PR DESCRIPTION
A new method `buffer_t:fill_partially` allows to specify the number of bytes to copy to a buffer. Added as a separate method instead of overloading `fill` because they have identical signatures.

`command_buffer_t:draw_vertices` now has a new overload that allows to specify the number of vertices to draw.