### PR TITLE
Added method `command_buffer_t::prepare_for_reuse`

### DIFF
--- a/include/avk/command_buffer.hpp
+++ b/include/avk/command_buffer.hpp
@@ -124,6 +124,13 @@ namespace avk
 		void copy_image(const image_t& aSource, const vk::Image& aDestination);
 		void end_render_pass();
 
+		/** Prepare a command buffer for re-recording.
+		*   This essentially calls (and removes) any custom deleters, and removes any post-execution-handlers.
+		*   Call this method before re-recording an existing command buffer.
+		*/
+		void prepare_for_reuse();
+
+
 		/**	Draw vertices with vertex buffer bindings starting at BUFFER-BINDING #0 top to the number of total buffers passed -1.
 		 *	"BUFFER-BINDING" means that it corresponds to the binding specified in `input_binding_location_data::from_buffer_at_binding`.
 		 *	There can be no gaps between buffer bindings.

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -2520,6 +2520,21 @@ namespace avk
 		return result;
 	}
 
+	// prepare command buffer for re-recording
+	void command_buffer_t::prepare_for_reuse()
+	{
+		if (mPostExecutionHandler.has_value()) {
+			// Clear post-execution handler
+			mPostExecutionHandler.reset();
+		}
+		if (mCustomDeleter.has_value() && *mCustomDeleter) {
+			// If there is a custom deleter => call it now
+			(*mCustomDeleter)();
+			mCustomDeleter.reset();
+		}
+	}
+
+
 	command_buffer_t::~command_buffer_t()
 	{
 		if (mCustomDeleter.has_value() && *mCustomDeleter) {


### PR DESCRIPTION
This is needed before re-recording over an existing command buffer.
In a nutshell, it calls (and resets) any custom deleters, as well as
resets the post-execution-chain.