### PR TITLE
Enable depth bias in `depth_clamp_bias::dynamic()`

### DIFF
--- a/include/avk/graphics_pipeline_config.hpp
+++ b/include/avk/graphics_pipeline_config.hpp
@@ -247,7 +247,7 @@ namespace avk
 			static depth_clamp_bias config_nothing_special() { return { false, false, 0.0f, 0.0f, 0.0f, false }; }
 			static depth_clamp_bias config_enable_depth_bias(float pConstantFactor, float pBiasClamp, float pSlopeFactor) { return { false, true, pConstantFactor, pBiasClamp, pSlopeFactor, false }; }
 			static depth_clamp_bias config_enable_clamp_and_depth_bias(float pConstantFactor, float pBiasClamp, float pSlopeFactor) { return { true, true, pConstantFactor, pBiasClamp, pSlopeFactor, false }; }
-			static depth_clamp_bias dynamic() { return { false, false, 0.0f, 0.0f, 0.0f, true }; }
+			static depth_clamp_bias dynamic() { return { false, true, 0.0f, 0.0f, 0.0f, true }; } // also sets depth bias to enabled, otherwise this would be pointless
 
 			auto is_clamp_to_frustum_enabled() const { return mClampDepthToFrustum; }
 			auto is_depth_bias_enabled() const { return mEnableDepthBias; }


### PR DESCRIPTION
As there is no Vulkan command to dynamically enable depth bias, it would
be pointless to have the values in the dynamic state, but leave it disabled.