### PR TITLE
draw_indexed_indirect_count and fill-fix for zero bytes copy

### DIFF
--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -2348,28 +2348,38 @@ namespace avk
 			// We have to create a (somewhat temporary) staging buffer and transfer it to the GPU
 			// "somewhat temporary" means that it can not be deleted in this function, but only
 			//						after the transfer operation has completed => handle via sync
-			auto stagingBuffer = root::create_buffer(
-				mPhysicalDevice, mDevice, mBuffer.allocator(),
-				AVK_STAGING_BUFFER_MEMORY_USAGE,
-				vk::BufferUsageFlagBits::eTransferSrc,
-				generic_buffer_meta::create_from_size(dataSize)
-			);
-			stagingBuffer->fill(aDataPtr, 0, sync::wait_idle()); // Recurse into the other if-branch
+			// We need to take care though, to not try to allocate buffer of size zero here.
+			// If dataSize is zero, skip staging buffer creation and the copy command, but still
+			// process the synchronization calls, as user code may rely on those.
+			buffer stagingBuffer;
+			if (dataSize != 0) {
+				stagingBuffer = root::create_buffer(
+					mPhysicalDevice, mDevice, mBuffer.allocator(),
+					AVK_STAGING_BUFFER_MEMORY_USAGE,
+					vk::BufferUsageFlagBits::eTransferSrc,
+					generic_buffer_meta::create_from_size(dataSize)
+				);
+				stagingBuffer->fill(aDataPtr, 0, sync::wait_idle()); // Recurse into the other if-branch
+			}
 
 			auto& commandBuffer = aSyncHandler.get_or_create_command_buffer();
 			// Sync before:
 			aSyncHandler.establish_barrier_before_the_operation(pipeline_stage::transfer, read_memory_access{memory_access::transfer_read_access});
 
 			// Operation:
-			copy_buffer_to_another(avk::referenced(stagingBuffer), avk::referenced(*this), 0, static_cast<vk::DeviceSize>(aOffsetInBytes), dataSize, sync::with_barriers_into_existing_command_buffer(commandBuffer, {}, {}));
+			if (stagingBuffer.has_value()) {
+				copy_buffer_to_another(avk::referenced(stagingBuffer), avk::referenced(*this), 0, static_cast<vk::DeviceSize>(aOffsetInBytes), dataSize, sync::with_barriers_into_existing_command_buffer(commandBuffer, {}, {}));
+			}
 
 			// Sync after:
 			aSyncHandler.establish_barrier_after_the_operation(pipeline_stage::transfer, write_memory_access{memory_access::transfer_write_access});
 
 			// Take care of the lifetime handling of the stagingBuffer, it might still be in use:
-			commandBuffer.set_custom_deleter([
-				lOwnedStagingBuffer{ std::move(stagingBuffer) }
-			]() { /* Nothing to do here, the buffers' destructors will do the cleanup, the lambda is just storing it. */ });
+			if (stagingBuffer.has_value()) {
+				commandBuffer.set_custom_deleter([
+					lOwnedStagingBuffer{ std::move(stagingBuffer) }
+				]() { /* Nothing to do here, the buffers' destructors will do the cleanup, the lambda is just storing it. */ });
+			}
 			
 			// Finish him:
 			return aSyncHandler.submit_and_sync();			

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -2351,36 +2351,33 @@ namespace avk
 			// We need to take care though, to not try to allocate buffer of size zero here.
 			// If dataSize is zero, skip staging buffer creation and the copy command, but still
 			// process the synchronization calls, as user code may rely on those.
-			buffer stagingBuffer;
+
+			auto& commandBuffer = aSyncHandler.get_or_create_command_buffer();
+
+			// Sync before:
+			aSyncHandler.establish_barrier_before_the_operation(pipeline_stage::transfer, read_memory_access{memory_access::transfer_read_access});
+
 			if (dataSize != 0) {
-				stagingBuffer = root::create_buffer(
+				auto stagingBuffer = root::create_buffer(
 					mPhysicalDevice, mDevice, mBuffer.allocator(),
 					AVK_STAGING_BUFFER_MEMORY_USAGE,
 					vk::BufferUsageFlagBits::eTransferSrc,
 					generic_buffer_meta::create_from_size(dataSize)
 				);
 				stagingBuffer->fill(aDataPtr, 0, sync::wait_idle()); // Recurse into the other if-branch
-			}
 
-			auto& commandBuffer = aSyncHandler.get_or_create_command_buffer();
-			// Sync before:
-			aSyncHandler.establish_barrier_before_the_operation(pipeline_stage::transfer, read_memory_access{memory_access::transfer_read_access});
-
-			// Operation:
-			if (stagingBuffer.has_value()) {
+				// Operation:
 				copy_buffer_to_another(avk::referenced(stagingBuffer), avk::referenced(*this), 0, static_cast<vk::DeviceSize>(aOffsetInBytes), dataSize, sync::with_barriers_into_existing_command_buffer(commandBuffer, {}, {}));
+
+				// Take care of the lifetime handling of the stagingBuffer, it might still be in use when this method returns:
+				commandBuffer.set_custom_deleter([
+					lOwnedStagingBuffer{ std::move(stagingBuffer) }
+				]() { /* Nothing to do here, the buffers' destructors will do the cleanup, the lambda is just storing it. */ });
 			}
 
 			// Sync after:
 			aSyncHandler.establish_barrier_after_the_operation(pipeline_stage::transfer, write_memory_access{memory_access::transfer_write_access});
 
-			// Take care of the lifetime handling of the stagingBuffer, it might still be in use:
-			if (stagingBuffer.has_value()) {
-				commandBuffer.set_custom_deleter([
-					lOwnedStagingBuffer{ std::move(stagingBuffer) }
-				]() { /* Nothing to do here, the buffers' destructors will do the cleanup, the lambda is just storing it. */ });
-			}
-			
 			// Finish him:
 			return aSyncHandler.submit_and_sync();			
 		}


### PR DESCRIPTION
1. Added `command_buffer_t::draw_indexed_indirect_count`

2. Fixed `buffer_t::fill` with data size zero 
This used to crash/fail an assertion, if the buffer to fill is on device memory, due to trying to allocate a 0-byte staging buffer.
In the fixed version, both staging buffer creation and the copy command are skipped if data size is zero, but the synchronization calls are still executed, as they may be needed by the calling application.
