### PR TITLE
Cmake options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: |
-          curl -LS -o vulkan-sdk.exe https://vulkan.lunarg.com/sdk/home#sdk/downloadConfirm/latest/windows/vulkan-sdk.exe
+          curl -LS -o vulkan-sdk.exe https://sdk.lunarg.com/sdk/download/latest/windows/VulkanSDK-Installer.exe
 
           7z x vulkan-sdk.exe -o"${{ env.vulkan_sdk }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: |
-          curl -LS -o vulkan-sdk.exe https://vulkan.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe
+          curl -LS -o vulkan-sdk.exe https://vulkan.lunarg.com/sdk/home#sdk/downloadConfirm/latest/windows/vulkan-sdk.exe
 
           7z x vulkan-sdk.exe -o"${{ env.vulkan_sdk }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
-          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Davk_LibraryType=STATIC $GITHUB_WORKSPACE
 
       - name: Build
         shell: bash
@@ -118,7 +118,7 @@ jobs:
           $env:Path += ";${{ env.vulkan_sdk }}\;${{ env.vulkan_sdk }}\Bin\"
 
           # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
-          cmake ${{ runner.workspace }}/Auto-Vk -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G "Visual Studio 16 2019" -A x64
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Davk_LibraryType=STATIC ${{ runner.workspace }}/Auto-Vk -G "Visual Studio 16 2019" -A x64
 
       - name: Build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,33 @@ project(avk)
 
 set(CMAKE_CXX_STANDARD 20)
 
-add_library(${PROJECT_NAME} STATIC)
-target_include_directories(${PROJECT_NAME} PUBLIC
-        include)
-target_sources(${PROJECT_NAME} PUBLIC
-        src/avk.cpp
-        src/sync.cpp)
+set(avk_AllowedLibraryTypes INTERFACE SHARED STATIC)
+set(avk_LibraryType INTERFACE CACHE STRING
+        "The type of library avk should be built as. Must be one of ${avk_AllowedLibraryTypes}. Default: INTERFACE")
+set_property(CACHE avk_LibraryType PROPERTY STRINGS ${avk_AllowedLibraryTypes})
 
-find_package(Vulkan)
-target_include_directories(${PROJECT_NAME} PUBLIC
-    ${Vulkan_INCLUDE_DIR})
+if(NOT avk_LibraryType IN_LIST avk_AllowedLibraryTypes)
+    message(FATAL_ERROR "avk_LibraryType must be one of ${avk_AllowedLibraryTypes}")
+endif()
+
+option(avk_UseVMA "Use Vulkan Memory Allocator (VMA) for custom memory allocation." OFF)
+
+set(avk_IncludeDirs
+        include)
+set(avk_Sources
+        src/avk.cpp
+        src/sync.cpp
+        $<$<BOOL:${avk_UseVMA}>:src/vk_mem_alloc.cpp>)
+
+add_library(${PROJECT_NAME} ${avk_LibraryType})
+
+if(NOT avk_LibraryType STREQUAL "INTERFACE")
+    target_include_directories(${PROJECT_NAME} PUBLIC ${avk_IncludeDirs})
+    target_sources(${PROJECT_NAME} PUBLIC ${avk_Sources})
+    find_package(Vulkan)
+    target_include_directories(${PROJECT_NAME} PUBLIC
+        ${Vulkan_INCLUDE_DIR})
+else()
+    target_include_directories(${PROJECT_NAME} INTERFACE ${avk_IncludeDirs})
+    target_sources(${PROJECT_NAME} INTERFACE ${avk_Sources})
+endif()

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ _Auto-Vk_, however, allows to easily swap this straight-froward way of memory ha
 #define AVK_USE_VMA
 #include <avk/avk.hpp>
 ```
-Furthermore, add [`src/vk_mem_alloc.cpp`](src/vk_mem_alloc.cpp) to your source files. 
+Furthermore, add [`src/vk_mem_alloc.cpp`](src/vk_mem_alloc.cpp) to your source files. If you're using `CMake` you can do this by setting the `avk_UseVMA` option to `ON`.
 
 This is all that is required to set-up VMA to handle all internal memory allocations.
 


### PR DESCRIPTION
- fixes the current issues with the GitHub workflow (The download URL for the Vulkan SDK for Windows changed).
- adds a `CMake` option that allows users to add `src/vk_mem_alloc.cpp` to their sources.
- adds a `CMake` option that allows users to specify the library type for building `Auto-Vk`. Allowed options are `SHARED`, `STATIC`, `INTERFACE` (i.e. treat `Auto-Vk` as sources for the project that uses `Auto-Vk` directly). The default is `INTERFACE`, but `STATIC` is still used for the compiler checks.