### PR TITLE
Fix compiler check workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,29 +85,11 @@ jobs:
             cxx: "cl"
           }
         # todo: add more vulkan versions that should be tested (e.g. 1.1.x, or < 1.2.135)
-        vulkan-sdk: ["latest"] #, "1.2.176.1"]
+        vulkan-sdk: ["latest", "1.2.176.1"]
 
     steps:
       # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
       - uses: actions/checkout@v2
-      
-      # the download URL for the latest SDK version changes sometimes (every four months or so?)...
-      - name: Install Vulkan SDK
-        if: matrix.vulkan-sdk == 'latest'
-        # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
-        working-directory: ${{ runner.workspace }}/Auto-Vk
-        shell: pwsh
-        run: |
-          curl -LS -o vulkan-sdk.exe https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe
-          7z x vulkan-sdk.exe -o"${{ env.vulkan_sdk }}"
-      
-      # the download URL for the latest SDK version changes sometimes...
-      - name: Install Vulkan SDK
-        if: matrix.vulkan-sdk != 'latest'
-        run: |
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan-sdk }}/windows/VulkanSDK-${{ matrix.vulkan-sdk }}-Installer.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
-          $installer.WaitForExit();
 
       - name: Create Build Environment
         # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
@@ -116,6 +98,14 @@ jobs:
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: |
+          If (${{ matrix.vulkan-sdk }} -eq 'latest') {
+            # the download URL for the latest SDK version changes sometimes (every four months or so?)...
+            curl -LS -o vulkan-sdk.exe https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe
+          } Else {
+            curl -LS -o vulkan-sdk.exe https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan-sdk }}/windows/VulkanSDK-${{ matrix.vulkan-sdk }}-Installer.exe
+          }
+          7z x vulkan-sdk.exe -o"${{ env.vulkan_sdk }}"
+        
           # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
           cmake -E make_directory ${{ runner.workspace }}/Auto-Vk/build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: |
+          clang++ -v
           # Add lunarg apt sources
           wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list https://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         run: cmake --build . --config $BUILD_TYPE
 
   windows:
-    name: ${{ matrix.config.name }}
+    name: ${{ matrix.config.name }} using VulkanSDK version ${{ matrix.vulkan-sdk }}
     runs-on: windows-latest
     env:
       vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/"
@@ -85,7 +85,7 @@ jobs:
             cxx: "cl"
           }
         # todo: add more vulkan versions that should be tested (e.g. 1.1.x, or < 1.2.135)
-        vulkan-sdk: ["1.2.176.1", "latest"]
+        vulkan-sdk: ["latest"] #, "1.2.176.1"]
 
     steps:
       # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
@@ -104,7 +104,7 @@ jobs:
         if: matrix.vulkan-sdk != 'latest'
         run: |
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan-sdk }}/windows/VulkanSDK-${{ matrix.vulkan-sdk }}-Installer.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
+          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S" "/O" "${{ env.vulkan_sdk }}");
           $installer.WaitForExit();
 
       - name: Create Build Environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: |
-          clang++ -v
           # Add lunarg apt sources
           wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list https://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
@@ -44,6 +43,11 @@ jobs:
           # Install dependencies
           sudo apt-get install -y \
             vulkan-sdk
+            
+          # clang does not yet (<= 12) support "Down with typename" (P0634R3), which is used in libstdc++ >= 11 in the ranges-header
+          if [ "${{ matrix.config.cc }}" = "clang" ]; then
+            sudo apt remove libgcc-11-dev gcc-11
+          fi
 
           cmake -E make_directory ${{ runner.workspace }}/build
 
@@ -58,12 +62,6 @@ jobs:
         run: |
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
-          
-          # clang does not yet (<= 12) support "Down with typename" (P0634R3), which is used in libstdc++ >= 11 in the ranges-header
-          if [ "${{ matrix.config.cc }}" = "clang" ]; then
-            export CXXFLAGS="-stdlib=libc++"
-          fi
-          
           cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Davk_LibraryType=STATIC $GITHUB_WORKSPACE
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,8 @@ jobs:
       # the download URL for the latest SDK version changes sometimes (every four months or so?)...
       - name: Install Vulkan SDK
         if: matrix.vulkan-sdk == 'latest'
+        # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
+        working-directory: ${{ runner.workspace }}/Auto-Vk
         run: |
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe" -OutFile VulkanSDK.exe
           $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S /O `"${{ env.vulkan_sdk }}`"");

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,10 @@ jobs:
           - {
             name: "windows: msvc",
             cc: "cl",
-            cxx: "cl",
-            # todo: add more vulkan versions that should be tested (e.g. 1.1.x, or < 1.2.135)
-            vulkan-sdk: ["1.2.176.1", "latest"]
+            cxx: "cl"
           }
+        # todo: add more vulkan versions that should be tested (e.g. 1.1.x, or < 1.2.135)
+        vulkan-sdk: ["1.2.176.1", "latest"]
 
     steps:
       # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,12 @@ jobs:
         run: |
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
+          
+          # clang does not yet (<= 12) support "Down with typename" (P0634R3), which is used in libstdc++ >= 11 in the ranges-header
+          if [ "${{ matrix.config.cc }}" = "clang" ] then
+            export CXXFLAGS="-stdlib=libc++"
+          fi
+          
           cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Davk_LibraryType=STATIC $GITHUB_WORKSPACE
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
           }
           - {
             name: "linux: gcc",
-            cc: "gcc",
-            cxx: "g++"
+            cc: "gcc-10",
+            cxx: "g++-10"
           }
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
         config:
           - {
             name: "linux: clang",
-            cc: "clang-11",
-            cxx: "clang++-11"
+            cc: "clang",
+            cxx: "clang++"
           }
           - {
             name: "linux: gcc",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   linux:
-    name: ${{ matrix.config.name }}
+    name: ${{ matrix.config.name }} using VulkanSDK version ${{ matrix.vulkan-sdk }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -24,6 +24,9 @@ jobs:
             cc: "gcc-10",
             cxx: "g++-10"
           }
+        # note: if a specific vulkan version (e.g. 1.1.x, or < 1.2.135) needs testing, you can add it here:
+        # (not that ubuntu-latest (20.04) only supports >= v1.2.148 via apt)
+        vulkan-sdk: ["latest", "1.2.148"]
 
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +38,11 @@ jobs:
         run: |
           # Add lunarg apt sources
           wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list https://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
+          if [ "${{ matrix.vulkan-sdk }}" = "latest" ]; then          
+            sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list https://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
+          else
+            sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-${{ matrix.vulkan-sdk }}-focal.list https://packages.lunarg.com/vulkan/${{ matrix.vulkan-sdk }}/lunarg-vulkan-${{ matrix.vulkan-sdk }}-focal.list
+          fi
 
           # Update package lists
           sudo apt-get update -qq
@@ -84,7 +91,7 @@ jobs:
             cc: "cl",
             cxx: "cl"
           }
-        # todo: add more vulkan versions that should be tested (e.g. 1.1.x, or < 1.2.135)
+        # note: if a specific vulkan version (e.g. 1.1.x, or < 1.2.135) needs testing, you can add it here:
         vulkan-sdk: ["latest", "1.2.176.1"]
 
     steps:
@@ -93,7 +100,7 @@ jobs:
 
       - name: Create Build Environment
         # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
-        working-directory: ${{ runner.workspace }}/Auto-Vk
+        working-directory: ${{ runner.workspace }}/${{ github.event.repository.name }}
         shell: pwsh
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
@@ -107,14 +114,14 @@ jobs:
           7z x vulkan-sdk.exe -o"${{ env.vulkan_sdk }}"
         
           # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
-          cmake -E make_directory ${{ runner.workspace }}/Auto-Vk/build
+          cmake -E make_directory ${{ runner.workspace }}/${{ github.event.repository.name }}/build
 
       - name: Configure CMake
         # Use a bash shell so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: pwsh
         # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
-        working-directory: ${{ runner.workspace }}/Auto-Vk/build
+        working-directory: ${{ runner.workspace }}/${{ github.event.repository.name }}/build
         # Note the current convention is to use the -S and -B options here to specify source
         # and build directories, but this is only available with CMake 3.13 and higher.
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
@@ -124,11 +131,11 @@ jobs:
           $env:Path += ";${{ env.vulkan_sdk }}\;${{ env.vulkan_sdk }}\Bin\"
 
           # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Davk_LibraryType=STATIC ${{ runner.workspace }}/Auto-Vk -G "Visual Studio 16 2019" -A x64
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Davk_LibraryType=STATIC ${{ runner.workspace }}/${{ github.event.repository.name }} -G "Visual Studio 16 2019" -A x64
 
       - name: Build
         shell: bash
         # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
-        working-directory: ${{ runner.workspace }}/Auto-Vk/build
+        working-directory: ${{ runner.workspace }}/${{ github.event.repository.name }}/build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
         run: cmake --build . --config $BUILD_TYPE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
           }
           - {
             name: "linux: gcc",
-            cc: "gcc-10",
-            cxx: "g++-10"
+            cc: "gcc",
+            cxx: "g++"
           }
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           export CXX=${{ matrix.config.cxx }}
           
           # clang does not yet (<= 12) support "Down with typename" (P0634R3), which is used in libstdc++ >= 11 in the ranges-header
-          if [ "${{ matrix.config.cc }}" = "clang" ] then
+          if [ "${{ matrix.config.cc }}" = "clang" ]; then
             export CXXFLAGS="-stdlib=libc++"
           fi
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: |
-          If (${{ matrix.vulkan-sdk }} -eq 'latest') {
+          If ('${{ matrix.vulkan-sdk }}' -eq 'latest') {
             # the download URL for the latest SDK version changes sometimes (every four months or so?)...
             curl -LS -o vulkan-sdk.exe https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe
           } Else {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,12 +82,30 @@ jobs:
           - {
             name: "windows: msvc",
             cc: "cl",
-            cxx: "cl"
+            cxx: "cl",
+            # todo: add more vulkan versions that should be tested (e.g. 1.1.x, or < 1.2.135)
+            vulkan-sdk: ["1.2.176.1", "latest"]
           }
 
     steps:
       # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
       - uses: actions/checkout@v2
+      
+      # the download URL for the latest SDK version changes sometimes (every four months or so?)...
+      - name: Install Vulkan SDK
+        if: matrix.vulkan-sdk == 'latest'
+        run: |
+          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe" -OutFile VulkanSDK.exe
+          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
+          $installer.WaitForExit();
+      
+      # the download URL for the latest SDK version changes sometimes...
+      - name: Install Vulkan SDK
+        if: matrix.vulkan-sdk != 'latest'
+        run: |
+          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan-sdk }}/windows/VulkanSDK-${{ matrix.vulkan-sdk }}-Installer.exe" -OutFile VulkanSDK.exe
+          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
+          $installer.WaitForExit();
 
       - name: Create Build Environment
         # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
@@ -96,10 +114,6 @@ jobs:
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
         run: |
-          curl -LS -o vulkan-sdk.exe https://sdk.lunarg.com/sdk/download/latest/windows/VulkanSDK-Installer.exe
-
-          7z x vulkan-sdk.exe -o"${{ env.vulkan_sdk }}"
-
           # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
           cmake -E make_directory ${{ runner.workspace }}/Auto-Vk/build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,10 +96,10 @@ jobs:
         if: matrix.vulkan-sdk == 'latest'
         # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
         working-directory: ${{ runner.workspace }}/Auto-Vk
+        shell: pwsh
         run: |
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S /O `"${{ env.vulkan_sdk }}`"");
-          $installer.WaitForExit();
+          curl -LS -o vulkan-sdk.exe https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe
+          7z x vulkan-sdk.exe -o"${{ env.vulkan_sdk }}"
       
       # the download URL for the latest SDK version changes sometimes...
       - name: Install Vulkan SDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: "Cross-platform check"
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'include/**'
+      - 'src/**'
+      - 'CMakeLists.txt'
+  pull_request:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,6 @@ jobs:
 
           # Update package lists
           sudo apt-get update -qq
-          
-          # Install GCC 10 (required for concepts)
-          sudo apt-get install -y \
-            gcc-10 \
-            g++-10
 
           # Install dependencies
           sudo apt-get install -y \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         if: matrix.vulkan-sdk == 'latest'
         run: |
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S" "/O" "${{ env.vulkan_sdk }}");
+          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S /O `"${{ env.vulkan_sdk }}`"");
           $installer.WaitForExit();
       
       # the download URL for the latest SDK version changes sometimes...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
         config:
           - {
             name: "linux: clang",
-            cc: "clang",
-            cxx: "clang++"
+            cc: "clang-11",
+            cxx: "clang++-11"
           }
           - {
             name: "linux: gcc",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         if: matrix.vulkan-sdk == 'latest'
         run: |
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
+          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S" "/O" "${{ env.vulkan_sdk }}");
           $installer.WaitForExit();
       
       # the download URL for the latest SDK version changes sometimes...
@@ -104,7 +104,7 @@ jobs:
         if: matrix.vulkan-sdk != 'latest'
         run: |
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan-sdk }}/windows/VulkanSDK-${{ matrix.vulkan-sdk }}-Installer.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S" "/O" "${{ env.vulkan_sdk }}");
+          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
           $installer.WaitForExit();
 
       - name: Create Build Environment

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ _Auto-Vk_ consists of multiple C++ include files, two mandatory C++ source files
 * Add [`src/avk.cpp`](src/avk.cpp) (and currently also [`src/sync.cpp`](src/sync.cpp)) as a compiled C++ source code file
 * *Optional:* Add [`src/vk_mem_alloc.cpp`](src/vk_mem_alloc.cpp) if you want to use [Vulkan Memory Allocator (VMA)](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator) for handling memory allocations. For configuration instructions, see section [Memory Allocation](https://github.com/cg-tuwien/Auto-Vk/blob/master/README.md#memory-allocation).
 
+#### Caveats
+* On `clang` (at least version <= 12) _Auto-Vk_ does not compile when using `libstdc++` version 11 or higher, because `clang` doesn't yet support "Down with `typename`!" ([P0634R3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0634r3.html)), which is used in the `libstdc++` `ranges`-header.
 # Motivating Example
 
 _Auto-Vk_ aims to hit the sweet spot between full controllability and convenience without having a noticeable impact on performance.


### PR DESCRIPTION
Additions:
 - Check multiple VulkanSDK versions on Linux and Windows (please adjust as you see fit)
 - Note about `clang`'s incompatibility with `libstdc++` v. 11 or higher in readme

Fixes:
 - Installation of latest VulkanSDK on Windows
 - Building with `clang`

Changes:
 - Only trigger compiler check workflow on PRs and code changes.

Note that the download URL for the latest VulkanSDK version for Windows might change again (it's always either `.../vulkan-sdk.exe` or `.../Vulkan-Installer.exe` depending on the weather).