### PR TITLE
Use std:c++latest for MSVC builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         shell: bash
         working-directory: ${{ runner.workspace }}/build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: cmake --build . --config $BUILD_TYPE
+        run: cmake --build .
 
   windows:
     name: ${{ matrix.config.name }} using VulkanSDK version ${{ matrix.vulkan-sdk }}
@@ -144,4 +144,4 @@ jobs:
         # apparently checkout@v2 pulls to Auto-Vk/Auto-Vk on windows
         working-directory: ${{ runner.workspace }}/${{ github.event.repository.name }}/build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: cmake --build . --config $BUILD_TYPE
+        run: cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,22 @@ endif()
 add_library(${PROJECT_NAME} ${avk_LibraryType})
 
 if(NOT avk_LibraryType STREQUAL "INTERFACE")
+    if (MSVC)
+        target_compile_options(${PROJECT_NAME}
+            PUBLIC "/std:c++latest")
+    endif (MSVC)
+
     target_include_directories(${PROJECT_NAME} PUBLIC ${avk_IncludeDirs})
     target_sources(${PROJECT_NAME} PUBLIC ${avk_Sources})
     find_package(Vulkan)
     target_include_directories(${PROJECT_NAME} PUBLIC
         ${Vulkan_INCLUDE_DIR})
 else()
+    if (MSVC)
+        target_compile_options(${PROJECT_NAME}
+            INTERFACE "/std:c++latest")
+    endif (MSVC)
+
     target_include_directories(${PROJECT_NAME} INTERFACE ${avk_IncludeDirs})
     target_sources(${PROJECT_NAME} INTERFACE ${avk_Sources})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.13)
 project(avk)
 
-set(CMAKE_CXX_STANDARD 20)
+if (MSVC)
+    # <ranges> support requires /std:c++latest on MSVC
+    set(CMAKE_CXX_STANDARD 23)
+else (MSVC)
+    set(CMAKE_CXX_STANDARD 20)
+endif (MSVC)
 
 set(avk_AllowedLibraryTypes INTERFACE SHARED STATIC)
 set(avk_LibraryType INTERFACE CACHE STRING
@@ -27,22 +32,12 @@ endif()
 add_library(${PROJECT_NAME} ${avk_LibraryType})
 
 if(NOT avk_LibraryType STREQUAL "INTERFACE")
-    if (MSVC)
-        target_compile_options(${PROJECT_NAME}
-            PUBLIC "/std:c++latest")
-    endif (MSVC)
-
     target_include_directories(${PROJECT_NAME} PUBLIC ${avk_IncludeDirs})
     target_sources(${PROJECT_NAME} PUBLIC ${avk_Sources})
     find_package(Vulkan)
     target_include_directories(${PROJECT_NAME} PUBLIC
         ${Vulkan_INCLUDE_DIR})
 else()
-    if (MSVC)
-        target_compile_options(${PROJECT_NAME}
-            INTERFACE "/std:c++latest")
-    endif (MSVC)
-
     target_include_directories(${PROJECT_NAME} INTERFACE ${avk_IncludeDirs})
     target_sources(${PROJECT_NAME} INTERFACE ${avk_Sources})
 endif()


### PR DESCRIPTION
`std:c++20` doesn't enable `<ranges>` support. `c++latest` is required for that.
This PR sets `CMAKE_CXX_STANDARD 23` which maps to `c++-latest`.