### PR TITLE
Allow to modify renderpass create info

### DIFF
--- a/include/avk/avk.hpp
+++ b/include/avk/avk.hpp
@@ -858,7 +858,7 @@ namespace avk
 		 *										synchronization parameters.
 		 *	@param	aAlterConfigBeforeCreation	Use it to alter the renderpass_t configuration before it is actually being created.
 		 */
-		renderpass create_renderpass(std::vector<avk::attachment> aAttachments, std::function<void(renderpass_sync&)> aSync = {}, std::function<void(renderpass_t&)> aAlterConfigBeforeCreation = {});
+		renderpass create_renderpass(std::vector<avk::attachment> aAttachments, std::function<void(renderpass_sync&)> aSync = {}, std::function<void(renderpass_t&)> aAlterConfigBeforeCreation = {}, std::function<void(vk::RenderPassCreateInfo &)> aAlterCreateInfoBeforeCreation = {});
 
 		renderpass create_renderpass_from_template(resource_reference<const renderpass_t> aTemplate, std::function<void(renderpass_t&)> aAlterConfigBeforeCreation = {});
 #pragma endregion

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7042,7 +7042,7 @@ using namespace cpplinq;
 		}
 	}
 
-	renderpass root::create_renderpass(std::vector<avk::attachment> aAttachments, std::function<void(renderpass_sync&)> aSync, std::function<void(renderpass_t&)> aAlterConfigBeforeCreation)
+	renderpass root::create_renderpass(std::vector<avk::attachment> aAttachments, std::function<void(renderpass_sync&)> aSync, std::function<void(renderpass_t&)> aAlterConfigBeforeCreation, std::function<void(vk::RenderPassCreateInfo &)> aAlterCreateInfoBeforeCreation)
 	{
 		renderpass_t result;
 
@@ -7448,6 +7448,12 @@ using namespace cpplinq;
 			.setPSubpasses(result.mSubpasses.data())
 			.setDependencyCount(static_cast<uint32_t>(result.mSubpassDependencies.size()))
 			.setPDependencies(result.mSubpassDependencies.data());
+
+		// Maybe alter the createInfo itself?!
+		if (aAlterCreateInfoBeforeCreation) {
+			aAlterCreateInfoBeforeCreation(createInfo);
+		}
+
 		result.mRenderPass = device().createRenderPassUnique(createInfo);
 		return result;
 


### PR DESCRIPTION
Added an optional parameter `aAlterCreateInfoBeforeCreation` to `create_renderpass()`.
This allows to modify the `RenderPassCreateInfo` immediately before the
renderpass is created.