### PR TITLE
Extend acceleration structure meta and fix validation layer error

### DIFF
--- a/include/avk/buffer_meta.hpp
+++ b/include/avk/buffer_meta.hpp
@@ -1110,6 +1110,15 @@ namespace avk
 			return result; 
 		}
 
+		/** Create meta info from the total size of all elements. */
+		static read_only_input_to_acceleration_structure_builds_buffer_meta create_from_total_size(size_t aTotalSize, size_t aNumElements)
+		{
+			read_only_input_to_acceleration_structure_builds_buffer_meta result;
+			result.mSizeOfOneElement = aTotalSize / aNumElements;
+			result.mNumElements = aNumElements;
+			return result;
+		}
+
 		/** Create meta info from a STL-container like data structure or a single struct.
 		*	Container types must provide a `size()` method and the index operator.
 		*/

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -1637,7 +1637,6 @@ namespace avk
 				mPhysicalDevice, mDevice, mAllocator,
 				avk::memory_usage::device,
 #if VK_HEADER_VERSION >= 162
-				// TODO: Looks like no special usage flags are required anymore?
 				vk::BufferUsageFlagBits::eShaderDeviceAddressKHR
 				| vk::BufferUsageFlagBits::eStorageBuffer,
 #else

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -1638,7 +1638,8 @@ namespace avk
 				avk::memory_usage::device,
 #if VK_HEADER_VERSION >= 162
 				// TODO: Looks like no special usage flags are required anymore?
-				vk::BufferUsageFlagBits::eShaderDeviceAddressKHR,
+				vk::BufferUsageFlagBits::eShaderDeviceAddressKHR
+				| vk::BufferUsageFlagBits::eStorageBuffer,
 #else
 				vk::BufferUsageFlagBits::eRayTracingKHR | vk::BufferUsageFlagBits::eShaderDeviceAddressKHR,
 #endif


### PR DESCRIPTION
* Extend the `read_only_input_to_acceleration_structure_builds_buffer_meta` with the function `create_from_total_size(size_t aTotalSize, size_t aNumElements)`
* Add storage buffer bit for the scratch buffer