### PR TITLE
Use vkCmdWriteTimestamp2 instead

### DIFF
--- a/include/avk/shader_info.hpp
+++ b/include/avk/shader_info.hpp
@@ -66,6 +66,15 @@ namespace avk
 			return *this;
 		}
 		
+		inline bool direct_spirv() const {
+			return mSpVCode.has_value();
+		}
+
+		// There are two types available
+		// 1. Direct SPIR-V input: Valid fields are mSpVCode, mShaderType, mEntryPoint
+		// 2. File SPIR-V input: Valid fields are mPath, mShaderType, mEntryPoint, mDontMonitorFile
+
+		std::optional<std::vector<char>> mSpVCode;
 		std::string mPath;
 		avk::shader_type mShaderType;
 		std::string mEntryPoint;
@@ -76,10 +85,25 @@ namespace avk
 
 	static bool operator ==(const shader_info& left, const shader_info& right)
 	{
-		return are_paths_equal(left.mPath, right.mPath)
-			&& left.mShaderType == right.mShaderType 
+		if (left.direct_spirv() != right.direct_spirv()) {
+			return false;
+		}
+		else if (left.direct_spirv()
+			&& left.mShaderType == right.mShaderType
 			&& trim_spaces(left.mEntryPoint) == trim_spaces(right.mEntryPoint)
-			&& left.mSpecializationConstants == right.mSpecializationConstants;
+			&& left.mSpecializationConstants == right.mSpecializationConstants
+			&& left.mSpVCode == right.mSpVCode
+			) {
+			return true;
+		}
+		else {
+			return !left.direct_spirv()
+				&& are_paths_equal(left.mPath, right.mPath)
+				&& left.mShaderType == right.mShaderType
+				&& trim_spaces(left.mEntryPoint) == trim_spaces(right.mEntryPoint)
+				&& left.mSpecializationConstants == right.mSpecializationConstants;
+		}
+
 	}
 
 	static bool operator !=(const shader_info& left, const shader_info& right)

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7135,6 +7135,11 @@ namespace avk
 	{
 		auto shdr = shader::prepare(std::move(aInfo));
 
+		if (shdr.mInfo.direct_spirv()) {
+			shdr.mShaderModule = build_shader_module_from_binary_code(shdr.mInfo.mSpVCode.value());
+			return shdr;
+		}
+
 		if (std::filesystem::exists(shdr.info().mPath)) {
 			try {
 				shdr.mShaderModule = build_shader_module_from_file(shdr.info().mPath);
@@ -7193,6 +7198,7 @@ namespace avk
 
 		return shader_info
 		{
+			{},
 			std::move(pPath),
 			pShaderType.value(),
 			std::move(pEntryPoint),

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7536,7 +7536,7 @@ namespace avk
 				lHandle = handle(),
 				aQueryIndex
 			](avk::command_buffer_t& cb) {
-				cb.handle().writeTimestamp2KHR(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
+				cb.handle().writeTimestamp2(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
 			}
 		};
 	}


### PR DESCRIPTION
Hi,

Thanks for the awesome library! But a minor issue exists to prevent this library building out of the box.

This commit fixes the build problem under VS2019 with Vulkan 1.3.236.0 installed. The KHR singatured version will actually break when using Auto-Vk in its default settings, that is, statitically linking with the core functions while using dynamically linking with the extension functions.

Though Auto-Vk-Toolkit is not affected since it uses dynamically linking for all of its functions, I'm putting this fix here if anyone interested in using this library alone.

Please let me know if this fix is appropriate.

Thanks!
