### PR TITLE
Use vkCmdWriteTimestamp2 instead

### DIFF
--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7536,7 +7536,8 @@ namespace avk
 				lHandle = handle(),
 				aQueryIndex
 			](avk::command_buffer_t& cb) {
-				cb.handle().writeTimestamp2(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
+				cb.handle().writeTimestamp2KHR(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_ext());
+
 			}
 		};
 	}

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7536,7 +7536,7 @@ namespace avk
 				lHandle = handle(),
 				aQueryIndex
 			](avk::command_buffer_t& cb) {
-				cb.handle().writeTimestamp2KHR(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
+				cb.handle().writeTimestamp2(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
 			}
 		};
 	}


### PR DESCRIPTION
Hi,

Thanks for the awesome library! But a minor issue exists to prevent this library building out of the box.

This commit fixes the build problem under VS2019 with Vulkan 1.3.236.0 installed. The KHR singatured version will actually break when using Auto-Vk in its default settings, that is, statitically linking with the core functions while using dynamically linking with the extension functions.

Though Auto-Vk-Toolkit is not affected since it uses dynamically linking for all of its functions, I'm putting this fix here if anyone interested in using this library alone.

Please let me know if this fix is appropriate.

Thanks!