### PR TITLE
Fix destination offset for blitting

### DIFF
--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7259,8 +7259,9 @@ namespace avk
 				lSrcHandle = aSrcImage->handle(),
 				lDstHandle = aDstImage->handle(),
 				aSrcImageLayout, aDstImageLayout, aImageAspectFlags, aFilter,
-				lExtent = vk::Extent3D{ aSrcImage->width(), aSrcImage->height(), 1u },
-				dExtent = vk::Extent3D{ aDstImage->width(), aDstImage->height(), 1u }
+				lSrcExtent = vk::Extent3D{ aSrcImage->width(), aSrcImage->height(), 1u },
+				lDstExtent = vk::Extent3D{ aDstImage->width(), aDstImage->height(), 1u }
+
 			](avk::command_buffer_t& cb) {
 				const std::array srcOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(lExtent.width), static_cast<int32_t>(lExtent.height), 1 }};
 				const std::array dstOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(dExtent.width), static_cast<int32_t>(dExtent.height), 1 }};

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7263,8 +7263,8 @@ namespace avk
 				lDstExtent = vk::Extent3D{ aDstImage->width(), aDstImage->height(), 1u }
 
 			](avk::command_buffer_t& cb) {
-				const std::array srcOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(lExtent.width), static_cast<int32_t>(lExtent.height), 1 }};
-				const std::array dstOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(dExtent.width), static_cast<int32_t>(dExtent.height), 1 }};
+				const std::array srcOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(lSrcExtent.width), static_cast<int32_t>(lSrcExtent.height), 1 }};
+				const std::array dstOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(lDstExtent.width), static_cast<int32_t>(lDstExtent.height), 1 }};
 				const vk::ImageBlit region {
 					vk::ImageSubresourceLayers{ aImageAspectFlags, 0u, 0u, 1u }, srcOffsets,
 					vk::ImageSubresourceLayers{ aImageAspectFlags, 0u, 0u, 1u }, dstOffsets

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7259,10 +7259,11 @@ namespace avk
 				lSrcHandle = aSrcImage->handle(),
 				lDstHandle = aDstImage->handle(),
 				aSrcImageLayout, aDstImageLayout, aImageAspectFlags, aFilter,
-				lExtent = vk::Extent3D{ aSrcImage->width(), aSrcImage->height(), 1u }
+				lExtent = vk::Extent3D{ aSrcImage->width(), aSrcImage->height(), 1u },
+				dExtent = vk::Extent3D{ aDstImage->width(), aDstImage->height(), 1u }
 			](avk::command_buffer_t& cb) {
 				const std::array srcOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(lExtent.width), static_cast<int32_t>(lExtent.height), 1 }};
-				const std::array dstOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(lExtent.width), static_cast<int32_t>(lExtent.height), 1 }};
+				const std::array dstOffsets{ vk::Offset3D{ 0, 0, 0 }, vk::Offset3D{ static_cast<int32_t>(dExtent.width), static_cast<int32_t>(dExtent.height), 1 }};
 				const vk::ImageBlit region {
 					vk::ImageSubresourceLayers{ aImageAspectFlags, 0u, 0u, 1u }, srcOffsets,
 					vk::ImageSubresourceLayers{ aImageAspectFlags, 0u, 0u, 1u }, dstOffsets


### PR DESCRIPTION
The offset used for the destination image during blitting is based on the input image. This prevents scaling images with the blit command, which should be possible based on the [specification](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdBlitImage.html#_description).

This commit changes the destination extent to the size of the destination image to allow simple rescaling of images using the blit command.