### PR TITLE
Timeline semaphore support

### DIFF
--- a/include/avk/avk.hpp
+++ b/include/avk/avk.hpp
@@ -946,6 +946,11 @@ namespace avk
 #pragma region semaphore
 		static semaphore create_semaphore(vk::Device aDevice, const DISPATCH_LOADER_CORE_TYPE& aDispatchLoader, std::function<void(semaphore_t&)> aAlterConfigBeforeCreation = {});
 		semaphore create_semaphore(std::function<void(semaphore_t&)> aAlterConfigBeforeCreation = {});
+		/** \brief Creates a timeline semaphore
+		* \param aPayload					(optional) The initial value of the payload. Defaults to 0.
+		* \param aAlterConfigBeforeCreation (optional) Use it to alter the timeline semaphore configuration before it is actually being created.
+		* \return The created semaphore.
+		*/
 		semaphore create_timeline_semaphore(uint64_t aPayload = 0, std::function<void(semaphore_t&)> aAlterConfigBeforeCreation = {});
 #pragma endregion
 

--- a/include/avk/avk.hpp
+++ b/include/avk/avk.hpp
@@ -946,6 +946,7 @@ namespace avk
 #pragma region semaphore
 		static semaphore create_semaphore(vk::Device aDevice, const DISPATCH_LOADER_CORE_TYPE& aDispatchLoader, std::function<void(semaphore_t&)> aAlterConfigBeforeCreation = {});
 		semaphore create_semaphore(std::function<void(semaphore_t&)> aAlterConfigBeforeCreation = {});
+		semaphore create_timeline_semaphore(uint64_t aPayload = 0, std::function<void(semaphore_t&)> aAlterConfigBeforeCreation = {});
 #pragma endregion
 
 #pragma region shader

--- a/include/avk/commands.hpp
+++ b/include/avk/commands.hpp
@@ -1089,23 +1089,48 @@ namespace avk
 	{
 		avk::resource_argument<avk::semaphore_t> mWaitSemaphore;
 		avk::stage::pipeline_stage_flags mDstStage;
+		uint64_t mValue;
 	};
 
 	inline semaphore_wait_info operator>> (avk::resource_argument<avk::semaphore_t> a, avk::stage::pipeline_stage_flags b)
 	{
-		return semaphore_wait_info{ std::move(a), b };
+		return semaphore_wait_info{ std::move(a), b, 0 };
 	}
 
+	inline semaphore_wait_info&& operator| (uint64_t aValue, semaphore_wait_info&& aInfo)
+	{
+		aInfo.mValue = aValue;
+		return std::move(aInfo);
+	}
+
+	inline semaphore_wait_info& operator| (uint64_t aValue, semaphore_wait_info& aInfo)
+	{
+		aInfo.mValue = aValue;
+		return aInfo;
+	}
 
 	struct semaphore_signal_info
 	{
 		avk::stage::pipeline_stage_flags mSrcStage;
 		avk::resource_argument<avk::semaphore_t> mSignalSemaphore;
+		uint64_t mValue;
 	};
 
 	inline semaphore_signal_info operator>> (avk::stage::pipeline_stage_flags a, avk::resource_argument<avk::semaphore_t> b)
 	{
-		return semaphore_signal_info{ a, std::move(b) };
+		return semaphore_signal_info{ a, std::move(b), 0 };
+	}
+
+	inline semaphore_signal_info&& operator| (semaphore_signal_info&& aInfo, uint64_t aValue)
+	{
+		aInfo.mValue = aValue;
+		return std::move(aInfo);
+	}
+
+	inline semaphore_signal_info& operator| (semaphore_signal_info& aInfo, uint64_t aValue)
+	{
+		aInfo.mValue = aValue;
+		return aInfo;
 	}
 
 

--- a/include/avk/semaphore.hpp
+++ b/include/avk/semaphore.hpp
@@ -48,6 +48,13 @@ namespace avk
 		const auto& handle() const { return mSemaphore.get(); }
 		const auto* handle_addr() const { return &mSemaphore.get(); }
 
+		// timeline semaphore specific functions
+		const uint64_t query_current_value() const;
+		void signal(uint64_t aNewValue) const;
+		void wait_until_signalled(uint64_t aRequiredValue, std::optional<uint64_t> aTimeout = {}) const;
+		static void wait_until_signalled(const std::vector<const semaphore_t*> &aSemaphores, const std::vector<uint64_t> &aTimestamps, bool aWaitOnAll = true, std::optional<uint64_t> aTimeout = {});
+		static void wait_until_signalled(const vk::Device &d, const vk::SemaphoreWaitInfo &info, std::optional<uint64_t> aTimeout = {});
+
 	private:
 		// The semaphore config struct:
 		vk::SemaphoreCreateInfo mCreateInfo;

--- a/include/avk/semaphore.hpp
+++ b/include/avk/semaphore.hpp
@@ -49,11 +49,30 @@ namespace avk
 		const auto* handle_addr() const { return &mSemaphore.get(); }
 
 		// timeline semaphore specific functions
+
+		// returns the current value of the timeline semaphore
 		const uint64_t query_current_value() const;
+		// sets the timeline semaphore to the specified value
 		void signal(uint64_t aNewValue) const;
-		void wait_until_signalled(uint64_t aRequiredValue, std::optional<uint64_t> aTimeout = {}) const;
-		static void wait_until_signalled(const std::vector<const semaphore_t*> &aSemaphores, const std::vector<uint64_t> &aTimestamps, bool aWaitOnAll = true, std::optional<uint64_t> aTimeout = {});
-		static void wait_until_signalled(const vk::Device &d, const vk::SemaphoreWaitInfo &info, std::optional<uint64_t> aTimeout = {});
+		/** \brief Waits on host until the timiline semaphore reaches the given value or the timeout(in nanoseconds) happens.
+		* \return Value of type vk::Result containing information about whether the wait operation succeeded, or the timeout has been triggered.
+		*/
+		vk::Result wait_until_signalled(uint64_t aRequiredValue, std::optional<uint64_t> aTimeout = {}) const;
+		/** \brief Waits on host until the condition specified with the parameters is met.
+		* \param aSemaphores Vector of timeline semaphores that should be waited on. All semaphores are required to be owned by the same logical device.
+		* \param aTimestamps Vector of payload values to wait on. Is required to have the same size as aSemaphores. The n-th value in aTimestamps corresponds to the n-th entry in aSemaphores.
+		* \param aWaitOnAll (optional) If true, waits until ALL semaphores have reached their target timestamps. If false, waits until ANY semaphore has reached its target timestamp.
+		* \param aTimeout (optional) Defines a timeout (in nanoseconds) after which the function returns regardless of the semaphore state.
+		* \return Value of type vk::Result containing information about whether the wait operation succeeded, or the timeout has been triggered.
+		*/
+		static vk::Result wait_until_signalled(const std::vector<const semaphore_t*> &aSemaphores, const std::vector<uint64_t> &aTimestamps, bool aWaitOnAll = true, std::optional<uint64_t> aTimeout = {});
+		/** \brief Waits on host until the condition specified with the parameters is met.
+		* \param aDevice The logical device owning all referenced timeline semaphores.
+		* \param aInfo Struct containing all relevant information about the wait operation.
+		* \param aTimeout (optional) Defines a timeout (in nanoseconds) after which the function returns regardless of the semaphore state.
+		* \return Value of type vk::Result containing information about whether the wait operation succeeded, or the timeout has been triggered.
+		*/
+		static vk::Result wait_until_signalled(const vk::Device &aDevice, const vk::SemaphoreWaitInfo &aInfo, std::optional<uint64_t> aTimeout = {});
 
 	private:
 		// The semaphore config struct:

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7144,14 +7144,14 @@ namespace avk
 		mSemaphore.getOwner().signalSemaphore(info);
 	}
 
-	void semaphore_t::wait_until_signalled(uint64_t aRequiredValue, std::optional<uint64_t> aTimeout) const {
-		wait_until_signalled({ this }, {aRequiredValue} , true, aTimeout);
+	vk::Result semaphore_t::wait_until_signalled(uint64_t aRequiredValue, std::optional<uint64_t> aTimeout) const {
+		return wait_until_signalled({ this }, {aRequiredValue} , true, aTimeout);	// maybe avoid unnecessary vector construction by just creating SemaphoreWaitInfo in this function
 	}
 
-	void semaphore_t::wait_until_signalled(const std::vector<const semaphore_t*>& aSemaphores, const std::vector<uint64_t>& aTimestamps, bool aWaitOnAll, std::optional<uint64_t> aTimeout) {
+	vk::Result semaphore_t::wait_until_signalled(const std::vector<const semaphore_t*>& aSemaphores, const std::vector<uint64_t>& aTimestamps, bool aWaitOnAll, std::optional<uint64_t> aTimeout) {
 		assert(aSemaphores.size() == aTimestamps.size());
 		if (aSemaphores.size() == 0) {
-			return;
+			return vk::Result::eSuccess;
 		}
 
 		std::vector<const vk::Semaphore*> semaphores;
@@ -7166,12 +7166,13 @@ namespace avk
 		info.pValues = aTimestamps.data();
 
 		// assume all semapores use the same device
-		wait_until_signalled(aSemaphores.front()->mSemaphore.getOwner(), info, aTimeout);
+		return wait_until_signalled(aSemaphores.front()->mSemaphore.getOwner(), info, aTimeout);
 	}
 
-	void semaphore_t::wait_until_signalled(const vk::Device& d, const vk::SemaphoreWaitInfo& info, std::optional<uint64_t> aTimeout) {
-		auto result = d.waitSemaphores(info, aTimeout.value_or(UINT64_MAX));
+	vk::Result semaphore_t::wait_until_signalled(const vk::Device& aDevice, const vk::SemaphoreWaitInfo& aInfo, std::optional<uint64_t> aTimeout) {
+		auto result = aDevice.waitSemaphores(aInfo, aTimeout.value_or(UINT64_MAX));
 		assert(static_cast<VkResult>(result) >= 0);
+		return result;
 	}
 
 #pragma endregion

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7103,15 +7103,46 @@ namespace avk
 		return create_semaphore(device(), dispatch_loader_core(), std::move(aAlterConfigBeforeCreation));
 	}
 
+	semaphore root::create_timeline_semaphore(uint64_t aPayload, std::function<void(semaphore_t&)> aAlterConfigBeforeCreation)
+	{
+		return create_semaphore(device(), dispatch_loader_core(), [otherAlterations = move(aAlterConfigBeforeCreation), aPayload](semaphore_t& aSem) {
+			auto typeInfo = std::make_unique<vk::SemaphoreTypeCreateInfo>();
+			typeInfo->semaphoreType = vk::SemaphoreType::eTimeline;
+			typeInfo->initialValue = aPayload;
+
+			aSem.create_info().pNext = typeInfo.get();
+			aSem.set_custom_deleter([aTypeInfo = move(typeInfo)]() { /* Do nothing ... this lambda just keeps the typeInfo struct alive */ });
+			// maybe extend any_owning_resource_t and use handle_lifetime_of instead?
+
+			if (otherAlterations) {
+				otherAlterations(aSem);
+			}
+		});
+	}
+
 	semaphore_t& semaphore_t::handle_lifetime_of(any_owning_resource_t aResource)
 	{
 		mLifetimeHandledResources.push_back(std::move(aResource));
 		return *this;
 	}
 
-	const uint64_t semaphore_t::query_current_value() const { return 0; /* TODO */ }
+	const uint64_t semaphore_t::query_current_value() const {
+		uint64_t value;
+		auto result = mSemaphore.getOwner().getSemaphoreCounterValue(mSemaphore.get(), &value);
+		assert(static_cast<VkResult>(result) >= 0);
+		return value;
+	}
 
-	void semaphore_t::signal(uint64_t aNewValue) const { /* TODO */ }	// unsure if signaling changes any of the data managed by this class ... maybe need to remove const
+	void semaphore_t::signal(uint64_t aNewValue) const {
+
+		vk::SemaphoreSignalInfo info{};
+		info.sType = vk::StructureType::eSemaphoreSignalInfo;
+		info.pNext = NULL;
+		info.semaphore = mSemaphore.get();
+		info.value = aNewValue;
+
+		mSemaphore.getOwner().signalSemaphore(info);
+	}
 
 	void semaphore_t::wait_until_signalled(uint64_t aRequiredValue, std::optional<uint64_t> aTimeout) const {
 		wait_until_signalled({ this }, {aRequiredValue} , true, aTimeout);
@@ -8494,7 +8525,7 @@ namespace avk
 		// Gather config for wait semaphores:
 		std::vector<vk::SemaphoreSubmitInfoKHR> waitSem;
 		for (auto& semWait : mSemaphoreWaits) {
-			auto& subInfo = waitSem.emplace_back(semWait.mWaitSemaphore->handle()); // TODO: What about timeline semaphores? (see 'value' param!)
+			auto& subInfo = waitSem.emplace_back(semWait.mWaitSemaphore->handle(), semWait.mValue);
 			std::visit(lambda_overload{
 				[&subInfo](const std::monostate&) {
 					subInfo.setStageMask(vk::PipelineStageFlagBits2KHR::eNone);
@@ -8527,7 +8558,7 @@ namespace avk
 		// Gather config for signal semaphores:
 		std::vector<vk::SemaphoreSubmitInfoKHR> signalSem;
 		for (auto& semSig : mSemaphoreSignals) {
-			auto& subInfo = signalSem.emplace_back(semSig.mSignalSemaphore->handle()); // TODO: What about timeline semaphores? (see 'value' param!)
+			auto& subInfo = signalSem.emplace_back(semSig.mSignalSemaphore->handle(), semSig.mValue);
 			std::visit(lambda_overload{
 				[&subInfo](const std::monostate&) {
 					subInfo.setStageMask(vk::PipelineStageFlagBits2KHR::eNone);

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7155,7 +7155,7 @@ namespace avk
 		}
 
 		std::vector<const vk::Semaphore*> semaphores;
-		std::transform(aSemaphores.begin(), aSemaphores.end(), semaphores.begin(), [](const semaphore_t* s) {return &s->mSemaphore.get(); });
+		std::transform(aSemaphores.begin(), aSemaphores.end(), std::back_inserter(semaphores), [](const semaphore_t* s) {return &s->mSemaphore.get(); });
 
 		vk::SemaphoreWaitInfo info{};
 		info.sType = vk::StructureType::eSemaphoreWaitInfo;

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -2,6 +2,8 @@
 #include <avk/avk_log.hpp>
 #include <avk/avk.hpp>
 
+#define _SILENCE_CXX20_CISCO646_REMOVED_WARNING
+
 namespace avk
 {
 #pragma region root definitions
@@ -7106,6 +7108,41 @@ namespace avk
 		mLifetimeHandledResources.push_back(std::move(aResource));
 		return *this;
 	}
+
+	const uint64_t semaphore_t::query_current_value() const { return 0; /* TODO */ }
+
+	void semaphore_t::signal(uint64_t aNewValue) const { /* TODO */ }	// unsure if signaling changes any of the data managed by this class ... maybe need to remove const
+
+	void semaphore_t::wait_until_signalled(uint64_t aRequiredValue, std::optional<uint64_t> aTimeout) const {
+		wait_until_signalled({ this }, {aRequiredValue} , true, aTimeout);
+	}
+
+	void semaphore_t::wait_until_signalled(const std::vector<const semaphore_t*>& aSemaphores, const std::vector<uint64_t>& aTimestamps, bool aWaitOnAll, std::optional<uint64_t> aTimeout) {
+		assert(aSemaphores.size() == aTimestamps.size());
+		if (aSemaphores.size() == 0) {
+			return;
+		}
+
+		std::vector<const vk::Semaphore*> semaphores;
+		std::transform(aSemaphores.begin(), aSemaphores.end(), semaphores.begin(), [](const semaphore_t* s) {return &s->mSemaphore.get(); });
+
+		vk::SemaphoreWaitInfo info{};
+		info.sType = vk::StructureType::eSemaphoreWaitInfo;
+		info.pNext = NULL;
+		info.flags = aWaitOnAll ? vk::SemaphoreWaitFlags() : vk::SemaphoreWaitFlagBits::eAny;
+		info.semaphoreCount = uint32_t(semaphores.size());
+		info.pSemaphores = *(semaphores.data());
+		info.pValues = aTimestamps.data();
+
+		// assume all semapores use the same device
+		wait_until_signalled(aSemaphores.front()->mSemaphore.getOwner(), info, aTimeout);
+	}
+
+	void semaphore_t::wait_until_signalled(const vk::Device& d, const vk::SemaphoreWaitInfo& info, std::optional<uint64_t> aTimeout) {
+		auto result = d.waitSemaphores(info, aTimeout.value_or(UINT64_MAX));
+		assert(static_cast<VkResult>(result) >= 0);
+	}
+
 #pragma endregion
 
 #pragma region shader definitions


### PR DESCRIPTION
Adds basic timeline semaphore support. Related issue: cg-tuwien/Auto-Vk-Toolkit#45

Changes:
Timeline semaphores functionality has been added to the existing class `avk::semaphore_t`, is well documented and nicely abstracted.


Note: I added comments to some parts I would like feedback on.