### PR TITLE
Fix tiling_linear property not beeing used when creating images

### DIFF
--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -807,7 +807,9 @@ namespace avk
 		avk::image_usage cleanedUpUsageFlagsForReadOnly = exclude(aImageUsageFlags, avk::image_usage::transfer_source | avk::image_usage::transfer_destination | avk::image_usage::sampled | avk::image_usage::read_only | avk::image_usage::presentable | avk::image_usage::shared_presentable | avk::image_usage::tiling_optimal | avk::image_usage::tiling_linear | avk::image_usage::sparse_memory_binding | avk::image_usage::cube_compatible | avk::image_usage::is_protected); // TODO: To be verified, it's just a guess.
 
 		auto targetLayout = isReadOnly ? vk::ImageLayout::eShaderReadOnlyOptimal : vk::ImageLayout::eGeneral; // General Layout or Shader Read Only Layout is the default
-		auto imageTiling = vk::ImageTiling::eOptimal; // Optimal is the default
+
+		bool tilingLinear = avk::has_flag(aImageUsageFlags, avk::image_usage::tiling_linear);
+		auto imageTiling = tilingLinear ? vk::ImageTiling::eLinear : vk::ImageTiling::eOptimal;
 		vk::ImageCreateFlags imageCreateFlags{};
 
 		if (avk::has_flag(aImageUsageFlags, avk::image_usage::transfer_source)) {


### PR DESCRIPTION
A small change I used for a project of mine.

* Adds a check in `determine_usage_layout_tiling_flags_based_on_image_usage` for `avk::image_usage::tiling_linear`.
* It defaults tilling to `vk::ImageTiling::eOptimal` only if `avk::image_usage::tiling_linear` is not present.