### PR TITLE
Include style and SBT fix

### DIFF
--- a/include/avk/acceleration_structure_size_requirements.hpp
+++ b/include/avk/acceleration_structure_size_requirements.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/attachment.hpp
+++ b/include/avk/attachment.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {
@@ -60,26 +60,26 @@ namespace avk
 		 */
 		static attachment declare_for(const image_view_t& aImageView, attachment_load_config aLoadOp, subpass_usages aUsageInSubpasses, attachment_store_config aStoreOp);
 
-		attachment& set_clear_color(std::array<float, 4> aColor)					{ mColorClearValue = aColor; return *this; }
-		attachment& set_depth_clear_value(float aDepthClear)						{ mDepthClearValue = aDepthClear; return *this; }
-		attachment& set_stencil_clear_value(uint32_t aStencilClear)					{ mStencilClearValue = aStencilClear; return *this; }
-		
-		attachment& set_load_operation(attachment_load_config aLoadOp)              { mLoadOperation = aLoadOp; return *this; }
-		attachment& set_store_operation(attachment_store_config aStoreOp)           { mStoreOperation = aStoreOp; return *this; }
-		attachment& set_stencil_load_operation(attachment_load_config aLoadOp)      { mStencilLoadOperation = aLoadOp; return *this; }
-		attachment& set_stencil_store_operation(attachment_store_config aStoreOp)   { mStencilStoreOperation = aStoreOp; return *this; }
-		
+		attachment& set_clear_color(std::array<float, 4> aColor) { mColorClearValue = aColor; return *this; }
+		attachment& set_depth_clear_value(float aDepthClear) { mDepthClearValue = aDepthClear; return *this; }
+		attachment& set_stencil_clear_value(uint32_t aStencilClear) { mStencilClearValue = aStencilClear; return *this; }
+
+		attachment& set_load_operation(attachment_load_config aLoadOp) { mLoadOperation = aLoadOp; return *this; }
+		attachment& set_store_operation(attachment_store_config aStoreOp) { mStoreOperation = aStoreOp; return *this; }
+		attachment& set_stencil_load_operation(attachment_load_config aLoadOp) { mStencilLoadOperation = aLoadOp; return *this; }
+		attachment& set_stencil_store_operation(attachment_store_config aStoreOp) { mStencilStoreOperation = aStoreOp; return *this; }
+
 		/** The color/depth/stencil format of the attachment */
 		auto format() const { return mFormat; }
-		
+
 		auto get_first_color_depth_input() const { return mSubpassUsages.first_color_depth_input_usage(); }
 
 		auto get_last_color_depth_input() const { return mSubpassUsages.last_color_depth_input_usage(); }
-		
+
 		auto is_used_as_depth_stencil_attachment() const { return mSubpassUsages.contains_depth_stencil(); }
 
 		auto is_used_as_color_attachment() const { return mSubpassUsages.contains_color(); }
-		
+
 		auto is_used_as_input_attachment() const { return mSubpassUsages.contains_input(); }
 
 		/** True if the sample count is greater than 1 */

--- a/include/avk/avk.hpp
+++ b/include/avk/avk.hpp
@@ -29,9 +29,9 @@
 #include <concepts>
 #include <ranges>
 
-#include <avk/avk_log.hpp>
-#include <avk/avk_error.hpp>
-#include <avk/cpp_utils.hpp>
+#include "avk/avk_log.hpp"
+#include "avk/avk_error.hpp"
+#include "avk/cpp_utils.hpp"
 
 // TODO: #include <vulkan/vulkan_core.h> => #if VK_HEADER_VERSION >= 162
 #define VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL 0
@@ -49,7 +49,7 @@
  *
  *	By default, such a staging buffer is created with avk::memory_usage::host_coherent
  *	if nothing else is specified. Feel free to specify a different value by defining
- *	the AVK_STAGING_BUFFER_MEMORY_USAGE macro before the #include <avk/avk.hpp>.
+ *	the AVK_STAGING_BUFFER_MEMORY_USAGE macro before the #include "avk/avk.hpp".
  *	Note, however, that host-visibility MUST be given, otherwise nothing will work anymore.
  */
 #if !defined(AVK_STAGING_BUFFER_MEMORY_USAGE)
@@ -64,7 +64,7 @@
   *
   *	By default, such a staging buffer is created with avk::memory_usage::host_visible
   *	if nothing else is specified. Feel free to specify a different value by defining
-  *	the AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE macro before the #include <avk/avk.hpp>.
+  *	the AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE macro before the #include "avk/avk.hpp".
   *	Note, however, that host-visibility MUST be given, otherwise nothing will work anymore.
   */
 #if !defined(AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE)
@@ -76,14 +76,14 @@ namespace avk
 	class root;
 }
 
-#include <avk/image_color_channel_order.hpp>
-#include <avk/image_color_channel_format.hpp>
-#include <avk/image_usage.hpp>
-#include <avk/filter_mode.hpp>
-#include <avk/border_handling_mode.hpp>
+#include "avk/image_color_channel_order.hpp"
+#include "avk/image_color_channel_format.hpp"
+#include "avk/image_usage.hpp"
+#include "avk/filter_mode.hpp"
+#include "avk/border_handling_mode.hpp"
 
-#include <avk/vk_utils.hpp>
-#include <avk/mapping_access.hpp>
+#include "avk/vk_utils.hpp"
+#include "avk/mapping_access.hpp"
 
 /** CONFIG SETTING: DISPATCH_LOADER_CORE_TYPE
  *
@@ -108,7 +108,7 @@ namespace avk
 /** CONFIG SETTING: AVK_USE_VMA
  *
  *	Define the macro AVK_USE_VMA to enable memory allocation via Vulkan Memory Allocator.
- *	Note 1: You'll have to #define AVK_USE_VMA before the #include <avk/avk.hpp> statement!
+ *	Note 1: You'll have to #define AVK_USE_VMA before the #include "avk/avk.hpp" statement!
  *	Note 2: Vulkan Memory Allocator is not enabled by default. By default, you'll get
  *	        a very straight-forward and unoptimized memory allocation behavior, where
  *	        one memory allocation is made per resource.
@@ -126,12 +126,12 @@ namespace avk
 #if !defined(AVK_MEM_BUFFER_HANDLE)
 #define AVK_MEM_BUFFER_HANDLE        avk::vma_handle<vk::Buffer>
 #endif
-#include <avk/vma_handle.hpp>
+#include "avk/vma_handle.hpp"
 #else
-#include <avk/mem_handle.hpp>
+#include "avk/mem_handle.hpp"
 #endif
 
-#include <avk/scoped_mapping.hpp>
+#include "avk/scoped_mapping.hpp"
 
 /** CONFIG SETTINGS: AVK_MEM_ALLOCATOR_TYPE, AVK_MEM_IMAGE_HANDLE, AVK_MEM_BUFFER_HANDLE
  *
@@ -140,7 +140,7 @@ namespace avk
  *	similar to avk::mem_handle or avk::vma_handle which manages memory allocations.
  *
  *	If you want to plug-in custom memory allocation behavior, define ALL THREE of these
- *	macros before the #include <avk/avk.hpp>
+ *	macros before the #include "avk/avk.hpp"
  *
  *	The default for these macros is "stupid" memory allocation behavior by the means of
  *	mem_handle which creates one memory allocation per resource. If the AVK_USE_VMA macro
@@ -157,31 +157,31 @@ namespace avk
 #define AVK_MEM_BUFFER_HANDLE        avk::mem_handle<vk::Buffer>
 #endif
 
-#include <avk/memory_access.hpp>
-#include <avk/memory_usage.hpp>
-#include <avk/layout.hpp>
-#include <avk/on_load.hpp>
-#include <avk/on_store.hpp>
-#include <avk/subpass_usage_type.hpp>
-#include <avk/subpass_usages.hpp>
+#include "avk/memory_access.hpp"
+#include "avk/memory_usage.hpp"
+#include "avk/layout.hpp"
+#include "avk/on_load.hpp"
+#include "avk/on_store.hpp"
+#include "avk/subpass_usage_type.hpp"
+#include "avk/subpass_usages.hpp"
 
-#include <avk/shader_type.hpp>
-#include <avk/pipeline_stage.hpp>
-#include <avk/stage_and_access.hpp>
+#include "avk/shader_type.hpp"
+#include "avk/pipeline_stage.hpp"
+#include "avk/stage_and_access.hpp"
 
-#include <avk/descriptor_alloc_request.hpp>
-#include <avk/descriptor_pool.hpp>
+#include "avk/descriptor_alloc_request.hpp"
+#include "avk/descriptor_pool.hpp"
 
 
-#include <avk/format_for.hpp>
-#include <avk/buffer_meta.hpp>
+#include "avk/format_for.hpp"
+#include "avk/buffer_meta.hpp"
 
-#include <avk/binding_data.hpp>
+#include "avk/binding_data.hpp"
 
-#include <avk/descriptor_set.hpp>
-#include <avk/descriptor_set_layout.hpp>
-#include <avk/set_of_descriptor_set_layouts.hpp>
-#include <avk/descriptor_cache.hpp>
+#include "avk/descriptor_set.hpp"
+#include "avk/descriptor_set_layout.hpp"
+#include "avk/set_of_descriptor_set_layouts.hpp"
+#include "avk/descriptor_cache.hpp"
 
 // Predefine command types:
 namespace avk
@@ -197,56 +197,56 @@ namespace avk
 	}
 }
 
-#include <avk/buffer.hpp>
-#include <avk/shader_info.hpp>
+#include "avk/buffer.hpp"
+#include "avk/shader_info.hpp"
 
-#include <avk/shader_binding_table.hpp>
-#include <avk/command_buffer.hpp>
-#include <avk/command_pool.hpp>
+#include "avk/shader_binding_table.hpp"
+#include "avk/command_buffer.hpp"
+#include "avk/command_pool.hpp"
 
-#include <avk/semaphore.hpp>
-#include <avk/fence.hpp>
+#include "avk/semaphore.hpp"
+#include "avk/fence.hpp"
 
-#include <avk/image.hpp>
-#include <avk/image_view.hpp>
-#include <avk/sampler.hpp>
-#include <avk/image_sampler.hpp>
-#include <avk/attachment.hpp>
+#include "avk/image.hpp"
+#include "avk/image_view.hpp"
+#include "avk/sampler.hpp"
+#include "avk/image_sampler.hpp"
+#include "avk/attachment.hpp"
 
-#include <avk/input_description.hpp>
-#include <avk/push_constants.hpp>
+#include "avk/input_description.hpp"
+#include "avk/push_constants.hpp"
 
 
-#include <avk/buffer_view.hpp>
-#include <avk/vertex_index_buffer_pair.hpp>
-#include <avk/subpass_dependency.hpp>
-#include <avk/renderpass.hpp>
-#include <avk/framebuffer.hpp>
+#include "avk/buffer_view.hpp"
+#include "avk/vertex_index_buffer_pair.hpp"
+#include "avk/subpass_dependency.hpp"
+#include "avk/renderpass.hpp"
+#include "avk/framebuffer.hpp"
 
-#include <avk/geometry_instance.hpp>
+#include "avk/geometry_instance.hpp"
 
-#include <avk/vk_utils2.hpp>
+#include "avk/vk_utils2.hpp"
 
-#include <avk/acceleration_structure_size_requirements.hpp>
-#include <avk/bottom_level_acceleration_structure.hpp>
-#include <avk/top_level_acceleration_structure.hpp>
-#include <avk/shader.hpp>
+#include "avk/acceleration_structure_size_requirements.hpp"
+#include "avk/bottom_level_acceleration_structure.hpp"
+#include "avk/top_level_acceleration_structure.hpp"
+#include "avk/shader.hpp"
 
-#include <avk/graphics_pipeline_config.hpp>
-#include <avk/compute_pipeline_config.hpp>
-#include <avk/ray_tracing_pipeline_config.hpp>
-#include <avk/graphics_pipeline.hpp>
-#include <avk/compute_pipeline.hpp>
-#include <avk/ray_tracing_pipeline.hpp>
+#include "avk/graphics_pipeline_config.hpp"
+#include "avk/compute_pipeline_config.hpp"
+#include "avk/ray_tracing_pipeline_config.hpp"
+#include "avk/graphics_pipeline.hpp"
+#include "avk/compute_pipeline.hpp"
+#include "avk/ray_tracing_pipeline.hpp"
 
-#include <avk/query_pool.hpp>
+#include "avk/query_pool.hpp"
 
-#include <avk/vulkan_helper_functions.hpp>
+#include "avk/vulkan_helper_functions.hpp"
 
-#include <avk/bindings.hpp>
+#include "avk/bindings.hpp"
 
-#include <avk/commands.hpp>
-#include <avk/queue.hpp>
+#include "avk/commands.hpp"
+#include "avk/queue.hpp"
 
 namespace avk
 {

--- a/include/avk/avk_error.hpp
+++ b/include/avk/avk_error.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <avk/avk.hpp>
 
 namespace avk
 {

--- a/include/avk/binding_data.hpp
+++ b/include/avk/binding_data.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/bindings.hpp
+++ b/include/avk/bindings.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 #include <type_traits>
 
 namespace avk

--- a/include/avk/border_handling_mode.hpp
+++ b/include/avk/border_handling_mode.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/bottom_level_acceleration_structure.hpp
+++ b/include/avk/bottom_level_acceleration_structure.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/buffer.hpp
+++ b/include/avk/buffer.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/buffer.hpp
+++ b/include/avk/buffer.hpp
@@ -100,8 +100,8 @@ namespace avk
 		
 		auto usage_flags() const	{ return mBufferUsageFlags; }
 		auto memory_properties() const          { return mBuffer.memory_properties(); }
-		const auto has_device_address() const { return mDeviceAddress.has_value(); }
-		const auto device_address() const { return mDeviceAddress.value(); }
+		auto has_device_address() const { return mDeviceAddress.has_value(); }
+		auto device_address() const { return mDeviceAddress.value(); }
 
 		/**	Returns a reference to the descriptor info. If no descriptor info exists yet,
 		 *	one is created, that includes the buffer handle, offset is set to 0, and

--- a/include/avk/buffer_meta.hpp
+++ b/include/avk/buffer_meta.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/buffer_view.hpp
+++ b/include/avk/buffer_view.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/command_buffer.hpp
+++ b/include/avk/command_buffer.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 #include "avk.hpp"
 

--- a/include/avk/command_pool.hpp
+++ b/include/avk/command_pool.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/commands.hpp
+++ b/include/avk/commands.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 #include "buffer.hpp"
 #include "image.hpp"

--- a/include/avk/compute_pipeline.hpp
+++ b/include/avk/compute_pipeline.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/compute_pipeline_config.hpp
+++ b/include/avk/compute_pipeline_config.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/cpp_utils.hpp
+++ b/include/avk/cpp_utils.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk_error.hpp"
 
 namespace avk
 {

--- a/include/avk/descriptor_alloc_request.hpp
+++ b/include/avk/descriptor_alloc_request.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/descriptor_cache.hpp
+++ b/include/avk/descriptor_cache.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/descriptor_pool.hpp
+++ b/include/avk/descriptor_pool.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/descriptor_set.hpp
+++ b/include/avk/descriptor_set.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/descriptor_set_layout.hpp
+++ b/include/avk/descriptor_set_layout.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/fence.hpp
+++ b/include/avk/fence.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/filter_mode.hpp
+++ b/include/avk/filter_mode.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/format_for.hpp
+++ b/include/avk/format_for.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/framebuffer.hpp
+++ b/include/avk/framebuffer.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/geometry_instance.hpp
+++ b/include/avk/geometry_instance.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/graphics_pipeline.hpp
+++ b/include/avk/graphics_pipeline.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/graphics_pipeline_config.hpp
+++ b/include/avk/graphics_pipeline_config.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/image.hpp
+++ b/include/avk/image.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk_error.hpp"
 
 namespace avk
 {

--- a/include/avk/image_color_channel_format.hpp
+++ b/include/avk/image_color_channel_format.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/image_color_channel_order.hpp
+++ b/include/avk/image_color_channel_order.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/image_sampler.hpp
+++ b/include/avk/image_sampler.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/image_usage.hpp
+++ b/include/avk/image_usage.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/image_view.hpp
+++ b/include/avk/image_view.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/input_description.hpp
+++ b/include/avk/input_description.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include<compare>
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/layout.hpp
+++ b/include/avk/layout.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/mapping_access.hpp
+++ b/include/avk/mapping_access.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/mem_handle.hpp
+++ b/include/avk/mem_handle.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/memory_access.hpp
+++ b/include/avk/memory_access.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/memory_usage.hpp
+++ b/include/avk/memory_usage.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/on_load.hpp
+++ b/include/avk/on_load.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/on_store.hpp
+++ b/include/avk/on_store.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/pipeline_stage.hpp
+++ b/include/avk/pipeline_stage.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/push_constants.hpp
+++ b/include/avk/push_constants.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/query_pool.hpp
+++ b/include/avk/query_pool.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/queue.hpp
+++ b/include/avk/queue.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 #include "avk.hpp"
 

--- a/include/avk/ray_tracing_pipeline.hpp
+++ b/include/avk/ray_tracing_pipeline.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/ray_tracing_pipeline.hpp
+++ b/include/avk/ray_tracing_pipeline.hpp
@@ -102,6 +102,7 @@ namespace avk
 		vk::UniqueHandle<vk::Pipeline, DISPATCH_LOADER_EXT_TYPE> mPipeline;
 
 		uint32_t mShaderGroupBaseAlignment;
+		uint32_t mShaderGroupHandleAlignment;
 		uint32_t mShaderGroupHandleSize;
 		buffer mShaderBindingTable; // TODO: support more than one shader binding table?
 

--- a/include/avk/ray_tracing_pipeline_config.hpp
+++ b/include/avk/ray_tracing_pipeline_config.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/renderpass.hpp
+++ b/include/avk/renderpass.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/sampler.hpp
+++ b/include/avk/sampler.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/semaphore.hpp
+++ b/include/avk/semaphore.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/set_of_descriptor_set_layouts.hpp
+++ b/include/avk/set_of_descriptor_set_layouts.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/shader.hpp
+++ b/include/avk/shader.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/shader_binding_table.hpp
+++ b/include/avk/shader_binding_table.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk 
 {

--- a/include/avk/shader_info.hpp
+++ b/include/avk/shader_info.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/shader_type.hpp
+++ b/include/avk/shader_type.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/stage_and_access.hpp
+++ b/include/avk/stage_and_access.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/subpass_dependency.hpp
+++ b/include/avk/subpass_dependency.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/subpass_usage_type.hpp
+++ b/include/avk/subpass_usage_type.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/subpass_usages.hpp
+++ b/include/avk/subpass_usages.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/top_level_acceleration_structure.hpp
+++ b/include/avk/top_level_acceleration_structure.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/vertex_index_buffer_pair.hpp
+++ b/include/avk/vertex_index_buffer_pair.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/vk_utils.hpp
+++ b/include/avk/vk_utils.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/vma_handle.hpp
+++ b/include/avk/vma_handle.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/include/avk/vulkan_helper_functions.hpp
+++ b/include/avk/vulkan_helper_functions.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -1,6 +1,6 @@
 #define NOMINMAX
 #include <avk/avk_log.hpp>
-#include <avk/avk.hpp>
+#include "avk/avk.hpp"
 
 namespace avk
 {

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -1542,12 +1542,8 @@ namespace avk
 			mScratchBuffer = root::create_buffer(
 				*mRoot,
 				avk::memory_usage::device,
-#if VK_HEADER_VERSION >= 189
-				vk::BufferUsageFlagBits::eStorageBuffer |
-#endif
 #if VK_HEADER_VERSION >= 162
-				vk::BufferUsageFlagBits::eShaderDeviceAddressKHR
-				| vk::BufferUsageFlagBits::eStorageBuffer,
+				vk::BufferUsageFlagBits::eShaderDeviceAddressKHR | vk::BufferUsageFlagBits::eStorageBuffer,
 #else
 				vk::BufferUsageFlagBits::eRayTracingKHR | vk::BufferUsageFlagBits::eShaderDeviceAddressKHR,
 #endif


### PR DESCRIPTION
This PR does two things:
1) Switching `#include` style to using quotes instead of angle brackets for Auto-Vk files
2) (Potentially?) fixing offsets of shader binding table buffers