### PR TITLE
Added switch between Synchronization2 API functions and core API functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,16 @@ _Auto-Vk_ offers some preprocessor settings which influence the internal behavio
     Expected value: None, just define `AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2` or don't.      
 	Example: `#define AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2` (_Not_ defined by default. I.e., by default the Synchronization 2 API functions are used.)      
 	When to use: If you're targeting Vulkan 1.3 and above only, define it! If you're targeting also Vulkan versions < 1.3, then do _not_ define it, but make sure to enable [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html)!
+- `DISPATCH_LOADER_CORE_TYPE`: Can be used to define a custom dispatch loader type for the core functions (those that do not require extensions + some of the swapchain functions) passed on to Vulkan-Hpp types and calls.    
+    Expected value: A type compatible with the `Dispatch` tempalte parameters used in Vulkan-Hpp.      
+    Example: `#define DISPATCH_LOADER_CORE_TYPE vk::DispatchLoaderStatic` (default value)     
+- `DISPATCH_LOADER_EXT_TYPE`: Can be used to define a custom dispatch loader type for the extension functions (all those which are not core or swapchain) passed on to Vulkan-Hpp types and calls.    
+    Expected value: A type compatible with the `Dispatch` tempalte parameters used in Vulkan-Hpp.      
+    Example: `#define DISPATCH_LOADER_EXT_TYPE vk::DispatchLoaderDynamic` (default value)     
+- `AVK_USE_VMA`: If defined before including `avk.hpp`, it changes the memory allocator used by _Auto-Vk_ internally to VMA.     
+    Expected value: None, just define `AVK_USE_VMA` or don't.      
+    Example: `#define AVK_USE_VMA` (_Not_ defined by default. I.e., by default VMA is not used internally.)      
+    Further information: See [Memory Allocation](#memory-allocation) section below.
 
 # Resource Management
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,20 @@ auto actionTypeCommand = myBuffer->fill(vertices, 0);
 ```
 The first parameter are the data, the second refers to the meta data index to use (in this case to the `vertex_buffer_meta`, but actually the data should be the same for all of the meta data entries anyways). This operation returns an instance of type `avk::command::action_type_command`. This indicates that there are (or might be) commands which still need to be submitted to a queue and executed there in order to complete the operation.
 
+## Preprocessor Settings
+
+_Auto-Vk_ offers some preprocessor settings which influence the internal behavior at some points. In order to change these settings, define the respective setting **before** including `avk.hpp`!
+- `AVK_STAGING_BUFFER_MEMORY_USAGE`: If defined before including `avk.hpp`, it can be used to change the memory type that staging buffers are created in.    
+    Expected value: A value of the `avk::memory_usage` enum.     
+	Example: `#define AVK_STAGING_BUFFER_MEMORY_USAGE	avk::memory_usage::host_coherent` (this is also the default value).
+- `AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE`: If defined before including `avk.hpp`, it can be used to change the memory type that readback buffers are created in.    
+    Expected value: A value of the `avk::memory_usage` enum.     
+	Example: `#define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE	avk::memory_usage::host_visible` (this is also the default value).
+- `AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE`: If defined before including `avk.hpp`, it changes _Auto-Vk_ internally s.t. it uses the `2KHR`-type Vulkan API functions from the [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html) extension instead of the `2`-type Vulkan API functions, which correspond to the Synchronization2 functions but have been promoted to core with [Vulkan 1.3](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.3-promotions).       
+    Expected value: None, just define `AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE` or don't.      
+	Example: `#define AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE` (_not_ defined by default.      
+	When to use: If you're targeting Vulkan 1.3 and above only, do not define it. If you're targeting also Vulkan versions < 1.3, then define it and enable [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html)!
+
 # Resource Management
 
 Resource management in _Auto-Vk_ is managed in a way which strongly relies on _move-only_ types. That means: Whenever a resource's destructor is being invoked, the resource is destroyed and its memory freed. Furthermore, where resources "live" can be totally controlled by the programmer: be it on the stack or on the heap, enabling both, efficient and versatile usage patterns. These policies require explicit and precise handling of _how_ resources are stored and passed around, especially when passing them as arguments to functions/methods.

--- a/README.md
+++ b/README.md
@@ -252,24 +252,24 @@ The first parameter are the data, the second refers to the meta data index to us
 
 ## Preprocessor Settings
 
-_Auto-Vk_ offers some preprocessor settings which influence the internal behavior at some points. In order to change these settings, define the respective setting **before** including `avk.hpp`!
+_Auto-Vk_ offers some preprocessor settings which influence its internal behavior. In order to change these settings, define the respective setting **before** including `avk.hpp`!
 - `AVK_STAGING_BUFFER_MEMORY_USAGE`: If defined before including `avk.hpp`, it can be used to change the memory type that staging buffers are created in.    
     Expected value: A value of the `avk::memory_usage` enum.     
 	Example: `#define AVK_STAGING_BUFFER_MEMORY_USAGE avk::memory_usage::host_coherent` (this is also the default value).
 - `AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE`: If defined before including `avk.hpp`, it can be used to change the memory type that readback buffers are created in.    
     Expected value: A value of the `avk::memory_usage` enum.     
-	Example: `#define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE avk::memory_usage::host_visible` (this is also the default value).
+	Example: `#define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE avk::memory_usage::host_visible` (default value).
 - `AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2`: If defined before including `avk.hpp`, it changes _Auto-Vk_ internally s.t. it uses the core `2`-type Vulkan API functions instead of the `2KHR`-type functions from the [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html) extension. There's a corresponding function for each one. The Synchronization2 functions have been promoted to core in [Vulkan 1.3](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.3-promotions).       
     Expected value: None, just define `AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2` or don't.      
 	Example: `#define AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2` (_Not_ defined by default. I.e., by default the Synchronization 2 API functions are used.)      
-	When to use: If you're targeting Vulkan 1.3 and above only, define it! If you're targeting also Vulkan versions < 1.3, then do _not_ define it, but make sure to enable [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html)!
+	When to use: If you're targeting Vulkan 1.3 and above only, define it! If you're targeting also Vulkan API versions smaller than 1.3, then do _not_ define it, but make sure to enable [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html)!
 - `DISPATCH_LOADER_CORE_TYPE`: Can be used to define a custom dispatch loader type for the core functions (those that do not require extensions + some of the swapchain functions) passed on to Vulkan-Hpp types and calls.    
-    Expected value: A type compatible with the `Dispatch` tempalte parameters used in Vulkan-Hpp.      
+    Expected value: A type compatible with the `Dispatch` template parameters used in Vulkan-Hpp.      
     Example: `#define DISPATCH_LOADER_CORE_TYPE vk::DispatchLoaderStatic` (default value)     
 - `DISPATCH_LOADER_EXT_TYPE`: Can be used to define a custom dispatch loader type for the extension functions (all those which are not core or swapchain) passed on to Vulkan-Hpp types and calls.    
-    Expected value: A type compatible with the `Dispatch` tempalte parameters used in Vulkan-Hpp.      
+    Expected value: A type compatible with the `Dispatch` template parameters used in Vulkan-Hpp.      
     Example: `#define DISPATCH_LOADER_EXT_TYPE vk::DispatchLoaderDynamic` (default value)     
-- `AVK_USE_VMA`: If defined before including `avk.hpp`, it changes the memory allocator used by _Auto-Vk_ internally to VMA.     
+- `AVK_USE_VMA`: If defined before including `avk.hpp`, it changes the memory allocator used by _Auto-Vk_ internally to the [Vulkan Memory Allocator](https://gpuopen.com/vulkan-memory-allocator/) (VMA).     
     Expected value: None, just define `AVK_USE_VMA` or don't.      
     Example: `#define AVK_USE_VMA` (_Not_ defined by default. I.e., by default VMA is not used internally.)      
     Further information: See [Memory Allocation](#memory-allocation) section below.

--- a/README.md
+++ b/README.md
@@ -255,14 +255,14 @@ The first parameter are the data, the second refers to the meta data index to us
 _Auto-Vk_ offers some preprocessor settings which influence the internal behavior at some points. In order to change these settings, define the respective setting **before** including `avk.hpp`!
 - `AVK_STAGING_BUFFER_MEMORY_USAGE`: If defined before including `avk.hpp`, it can be used to change the memory type that staging buffers are created in.    
     Expected value: A value of the `avk::memory_usage` enum.     
-	Example: `#define AVK_STAGING_BUFFER_MEMORY_USAGE	avk::memory_usage::host_coherent` (this is also the default value).
+	Example: `#define AVK_STAGING_BUFFER_MEMORY_USAGE avk::memory_usage::host_coherent` (this is also the default value).
 - `AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE`: If defined before including `avk.hpp`, it can be used to change the memory type that readback buffers are created in.    
     Expected value: A value of the `avk::memory_usage` enum.     
-	Example: `#define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE	avk::memory_usage::host_visible` (this is also the default value).
-- `AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE`: If defined before including `avk.hpp`, it changes _Auto-Vk_ internally s.t. it uses the `2KHR`-type Vulkan API functions from the [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html) extension instead of the `2`-type Vulkan API functions, which correspond to the Synchronization2 functions but have been promoted to core with [Vulkan 1.3](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.3-promotions).       
-    Expected value: None, just define `AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE` or don't.      
-	Example: `#define AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE` (_not_ defined by default.      
-	When to use: If you're targeting Vulkan 1.3 and above only, do not define it. If you're targeting also Vulkan versions < 1.3, then define it and enable [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html)!
+	Example: `#define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE avk::memory_usage::host_visible` (this is also the default value).
+- `AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2`: If defined before including `avk.hpp`, it changes _Auto-Vk_ internally s.t. it uses the core `2`-type Vulkan API functions instead of the `2KHR`-type functions from the [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html) extension. There's a corresponding function for each one. The Synchronization2 functions have been promoted to core in [Vulkan 1.3](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.3-promotions).       
+    Expected value: None, just define `AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2` or don't.      
+	Example: `#define AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2` (_Not_ defined by default. I.e., by default the Synchronization 2 API functions are used.)      
+	When to use: If you're targeting Vulkan 1.3 and above only, define it! If you're targeting also Vulkan versions < 1.3, then do _not_ define it, but make sure to enable [`VK_KHR_synchronization2`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html)!
 
 # Resource Management
 

--- a/include/avk/avk.hpp
+++ b/include/avk/avk.hpp
@@ -56,20 +56,29 @@
 #define AVK_STAGING_BUFFER_MEMORY_USAGE	avk::memory_usage::host_coherent
 #endif
 
- /** CONFIG SETTING: AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE
-  *
-  *	The following setting CAN be set BEFORE including avk.hpp in order to change
-  *	the behavior whenever staging buffers for reading back values are created
-  *	internally. 
-  *
-  *	By default, such a staging buffer is created with avk::memory_usage::host_visible
-  *	if nothing else is specified. Feel free to specify a different value by defining
-  *	the AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE macro before the #include "avk/avk.hpp".
-  *	Note, however, that host-visibility MUST be given, otherwise nothing will work anymore.
-  */
+/** CONFIG SETTING: AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE
+ *
+ *	The following setting CAN be set BEFORE including avk.hpp in order to change
+ *	the behavior whenever staging buffers for reading back values are created
+ *	internally. 
+ *
+ *	By default, such a staging buffer is created with avk::memory_usage::host_visible
+ *	if nothing else is specified. Feel free to specify a different value by defining
+ *	the AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE macro before the #include "avk/avk.hpp".
+ *	Note, however, that host-visibility MUST be given, otherwise nothing will work anymore.
+ */
 #if !defined(AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE)
 #define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE	avk::memory_usage::host_visible
 #endif
+
+/** CONFIG SETTING: AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+ *	If this is defined BEFORE including avk.hpp, the Vulkan API functions of the Synchronization2
+ *	extension are used instead of the core functions (that have been added with Vulkan 1.3.
+ *	E.g. for writing timestamps on the GPU:
+ *	 -   If AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE is defined, vkCmdWriteTimestamp2KHR is used.
+ *   -   Otherwise vkCmdWriteTimestamp2KHR is used.
+ *  Note: The former uses the dispatch_loader_ext(), while the latter uses dispatch_loader_core().
+ */
 
 namespace avk
 {

--- a/include/avk/avk.hpp
+++ b/include/avk/avk.hpp
@@ -68,17 +68,22 @@
  *	Note, however, that host-visibility MUST be given, otherwise nothing will work anymore.
  */
 #if !defined(AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE)
-#define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE	avk::memory_usage::host_visible
+#define AVK_STAGING_BUFFER_READBACK_MEMORY_USAGE avk::memory_usage::host_visible
 #endif
 
-/** CONFIG SETTING: AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
- *	If this is defined BEFORE including avk.hpp, the Vulkan API functions of the Synchronization2
- *	extension are used instead of the core functions (that have been added with Vulkan 1.3.
+/** CONFIG SETTING: AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2
+ *	If this is defined BEFORE including avk.hpp, the Vulkan API core functions are used 
+ *	instead of the Synchronization2 extension functions (which were promoted to core with
+ *	Vulkan 1.3). Concretely, this means that the ...2()-type functions are used (core)
+ *	instead of the ...2KHR-type functions (Synchronization2 a.k.a. VK_KHR_synchronization2).
  *	E.g. for writing timestamps on the GPU:
- *	 -   If AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE is defined, vkCmdWriteTimestamp2KHR is used.
+ *	 -   If AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2 is defined, vkCmdWriteTimestamp2 is used.
  *   -   Otherwise vkCmdWriteTimestamp2KHR is used.
- *  Note: The former uses the dispatch_loader_ext(), while the latter uses dispatch_loader_core().
+ *  Note: The former is used with dispatch_loader_core(), the latter with dispatch_loader_ext().
  */
+#if !defined(AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2)
+#define AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+#endif
 
 namespace avk
 {

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -7557,7 +7557,11 @@ namespace avk
 				lHandle = handle(),
 				aQueryIndex
 			](avk::command_buffer_t& cb) {
-				cb.handle().writeTimestamp2KHR(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
+#ifdef VK_VERSION_1_3
+				cb.handle().writeTimestamp2(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
+#else
+				cb.handle().writeTimestamp2KHR(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_ext());
+#endif
 			}
 		};
 	}

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -6874,7 +6874,7 @@ namespace avk
 		rewire_subpass_dependencies(subpassDependencies, memoryBarriers);
 
 		// Finally, create the render pass
-		result.mCreateInfo = vk::RenderPassCreateInfo2KHR()
+		result.mCreateInfo = vk::RenderPassCreateInfo2KHR{}
 			.setAttachmentCount(static_cast<uint32_t>(result.mAttachmentDescriptions.size()))
 			.setPAttachments(result.mAttachmentDescriptions.data())
 			.setSubpassCount(static_cast<uint32_t>(result.mSubpasses.size()))
@@ -7557,10 +7557,10 @@ namespace avk
 				lHandle = handle(),
 				aQueryIndex
 			](avk::command_buffer_t& cb) {
-#ifdef VK_VERSION_1_3
-				cb.handle().writeTimestamp2(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
-#else
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
 				cb.handle().writeTimestamp2KHR(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_ext());
+#else
+				cb.handle().writeTimestamp2(lTimestampStage, lHandle, aQueryIndex, cb.root_ptr()->dispatch_loader_core());
 #endif
 			}
 		};
@@ -7628,7 +7628,14 @@ namespace avk
 #pragma endregion
 
 #pragma region commands and sync
-	inline static void record_into_command_buffer(command_buffer_t& aCommandBuffer, const DISPATCH_LOADER_EXT_TYPE& aDispatchLoader, const std::vector<recorded_commands_t>& aRecordedCommandsAndSyncInstructions);
+	inline static void record_into_command_buffer(
+		command_buffer_t& aCommandBuffer, 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+		const DISPATCH_LOADER_EXT_TYPE& aDispatchLoaderExt,
+#else
+		const DISPATCH_LOADER_CORE_TYPE& aDispatchLoaderCore,
+#endif
+		const std::vector<recorded_commands_t>& aRecordedCommandsAndSyncInstructions);
 
 	template <typename T>
 	inline static T accumulate_sync_details(
@@ -7912,20 +7919,38 @@ namespace avk
 		return barrier;
 	}
 
-	inline static void record_into_command_buffer(command_buffer_t& aCommandBuffer, const DISPATCH_LOADER_EXT_TYPE& aDispatchLoader, const command::state_type_command& aStateCmd)
+	inline static void record_into_command_buffer(command_buffer_t& aCommandBuffer, 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+		const DISPATCH_LOADER_EXT_TYPE& aDispatchLoaderExt,
+#else
+		const DISPATCH_LOADER_CORE_TYPE& aDispatchLoaderCore,
+#endif
+		const command::state_type_command& aStateCmd)
 	{
 		if (aStateCmd.mFun) {
 			aStateCmd.mFun(aCommandBuffer);
 		}
 	}
 
-	inline static void record_into_command_buffer(command_buffer_t& aCommandBuffer, const DISPATCH_LOADER_EXT_TYPE& aDispatchLoader, const command::action_type_command& aActionCmd)
+	inline static void record_into_command_buffer(command_buffer_t& aCommandBuffer,
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+		const DISPATCH_LOADER_EXT_TYPE& aDispatchLoaderExt,
+#else
+		const DISPATCH_LOADER_CORE_TYPE& aDispatchLoaderCore,
+#endif
+		const command::action_type_command& aActionCmd)
 	{
 		if (aActionCmd.mBeginFun) {
 			aActionCmd.mBeginFun(aCommandBuffer);
 		}
 		if (!aActionCmd.mNestedCommandsAndSyncInstructions.empty()) {
-			record_into_command_buffer(aCommandBuffer, aDispatchLoader, aActionCmd.mNestedCommandsAndSyncInstructions);
+			record_into_command_buffer(aCommandBuffer, 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+				aDispatchLoaderExt,
+#else
+				aDispatchLoaderCore,
+#endif
+				aActionCmd.mNestedCommandsAndSyncInstructions);
 		}
 		if (aActionCmd.mEndFun) {
 			aActionCmd.mEndFun(aCommandBuffer);
@@ -7934,7 +7959,11 @@ namespace avk
 
 	inline static void record_into_command_buffer(
 		command_buffer_t& aCommandBuffer, 
-		const DISPATCH_LOADER_EXT_TYPE& aDispatchLoader, 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+		const DISPATCH_LOADER_EXT_TYPE& aDispatchLoaderExt,
+#else
+		const DISPATCH_LOADER_CORE_TYPE& aDispatchLoaderCore,
+#endif
 		const sync::sync_type_command& aSyncCmd, 
 		const std::vector<recorded_commands_t>& aRecordedCommandsAndSyncInstructions, 
 		int aRecordedStuffIndex)
@@ -7944,38 +7973,67 @@ namespace avk
 			auto dependencyInfo = vk::DependencyInfoKHR{}
 				.setMemoryBarrierCount(1u)
 				.setPMemoryBarriers(&barrier);
-			aCommandBuffer.handle().pipelineBarrier2KHR(dependencyInfo, aDispatchLoader);
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			aCommandBuffer.handle().pipelineBarrier2KHR(dependencyInfo, aDispatchLoaderExt);
+#else
+			aCommandBuffer.handle().pipelineBarrier2(dependencyInfo, aDispatchLoaderCore);
+#endif
 		}
 		else if (aSyncCmd.is_image_memory_barrier()) {
 			auto barrier = assemble_barrier_data<vk::ImageMemoryBarrier2KHR>(aSyncCmd, aRecordedCommandsAndSyncInstructions, aRecordedStuffIndex);
 			auto dependencyInfo = vk::DependencyInfoKHR{}
 				.setImageMemoryBarrierCount(1u)
 				.setPImageMemoryBarriers(&barrier);
-			aCommandBuffer.handle().pipelineBarrier2KHR(dependencyInfo, aDispatchLoader);
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			aCommandBuffer.handle().pipelineBarrier2KHR(dependencyInfo, aDispatchLoaderExt);
+#else
+			aCommandBuffer.handle().pipelineBarrier2(dependencyInfo, aDispatchLoaderCore);
+#endif
 		}
 		else if (aSyncCmd.is_buffer_memory_barrier()) {
 			auto barrier = assemble_barrier_data<vk::BufferMemoryBarrier2KHR>(aSyncCmd, aRecordedCommandsAndSyncInstructions, aRecordedStuffIndex);
 			auto dependencyInfo = vk::DependencyInfoKHR{}
 				.setBufferMemoryBarrierCount(1u)
 				.setPBufferMemoryBarriers(&barrier);
-			aCommandBuffer.handle().pipelineBarrier2KHR(dependencyInfo, aDispatchLoader);
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			aCommandBuffer.handle().pipelineBarrier2KHR(dependencyInfo, aDispatchLoaderExt);
+#else
+			aCommandBuffer.handle().pipelineBarrier2(dependencyInfo, aDispatchLoaderCore);
+#endif
 		}
 	}
 
-
 	void command_buffer_t::record(const avk::command::state_type_command& aToBeRecorded)
 	{
-		record_into_command_buffer(*this, root_ptr()->dispatch_loader_ext(), aToBeRecorded);
+		record_into_command_buffer(*this,
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			root_ptr()->dispatch_loader_ext(), 
+#else
+			root_ptr()->dispatch_loader_core(),
+#endif
+			aToBeRecorded);
 	}
 
 	void command_buffer_t::record(const avk::command::action_type_command& aToBeRecorded)
 	{
-		record_into_command_buffer(*this, root_ptr()->dispatch_loader_ext(), aToBeRecorded);
+		record_into_command_buffer(*this,
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			root_ptr()->dispatch_loader_ext(),
+#else
+			root_ptr()->dispatch_loader_core(),
+#endif
+			aToBeRecorded);
 	}
 
 	void command_buffer_t::record(const avk::sync::sync_type_command& aToBeRecorded)
 	{
-		record_into_command_buffer(*this, root_ptr()->dispatch_loader_ext(), aToBeRecorded, std::vector<recorded_commands_t>{}, 0);
+		record_into_command_buffer(*this,
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			root_ptr()->dispatch_loader_ext(),
+#else
+			root_ptr()->dispatch_loader_core(),
+#endif
+			aToBeRecorded, std::vector<recorded_commands_t>{}, 0);
 	}
 
 	void command_buffer_t::record(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions)
@@ -7984,29 +8042,63 @@ namespace avk
 			.into_command_buffer(*this, false); // Last parameter: do not call begin/end here!
 	}
 
-
 	struct recordee_visitors
 	{
 		void operator()(const command::state_type_command& vStateCmd) const {
-			record_into_command_buffer(mCommandBuffer, mDispatchLoaderExt, vStateCmd);
+			record_into_command_buffer(mCommandBuffer, 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+				mDispatchLoaderExt, 
+#else
+				mDispatchLoaderCore,
+#endif
+				vStateCmd);
 		}
 		void operator()(const command::action_type_command& vActionCmd) const {
-			record_into_command_buffer(mCommandBuffer, mDispatchLoaderExt, vActionCmd);
+			record_into_command_buffer(mCommandBuffer,
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+				mDispatchLoaderExt,
+#else
+				mDispatchLoaderCore,
+#endif
+				vActionCmd);
 			
 		}
 		void operator()(const sync::sync_type_command& vSyncCmd) const {
-			record_into_command_buffer(mCommandBuffer, mDispatchLoaderExt, vSyncCmd, mRecordedStuff, mCurrentIndexIntoRecordedStuff);
+			record_into_command_buffer(mCommandBuffer,
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+				mDispatchLoaderExt,
+#else
+				mDispatchLoaderCore,
+#endif
+				vSyncCmd, mRecordedStuff, mCurrentIndexIntoRecordedStuff);
 		}
 
 		command_buffer_t& mCommandBuffer;
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
 		const DISPATCH_LOADER_EXT_TYPE& mDispatchLoaderExt;
+#else
+		const DISPATCH_LOADER_CORE_TYPE& mDispatchLoaderCore;
+#endif
 		const std::vector<recorded_commands_t>& mRecordedStuff;
 		int mCurrentIndexIntoRecordedStuff;
 	};
 	
-	inline static void record_into_command_buffer(command_buffer_t& aCommandBuffer, const DISPATCH_LOADER_EXT_TYPE& aDispatchLoader, const std::vector<recorded_commands_t>& aRecordedCommandsAndSyncInstructions)
+	inline static void record_into_command_buffer(
+		command_buffer_t& aCommandBuffer, 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+		const DISPATCH_LOADER_EXT_TYPE& aDispatchLoaderExt,
+#else
+		const DISPATCH_LOADER_CORE_TYPE& aDispatchLoaderCore,
+#endif
+		const std::vector<recorded_commands_t>& aRecordedCommandsAndSyncInstructions)
 	{
-		recordee_visitors visitState{ aCommandBuffer, aDispatchLoader, aRecordedCommandsAndSyncInstructions, /* Current index: */ 0 };
+		recordee_visitors visitState{ aCommandBuffer, 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			aDispatchLoaderExt,
+#else
+			aDispatchLoaderCore,
+#endif
+			aRecordedCommandsAndSyncInstructions, /* Current index: */ 0 };
 		
 		const int n = static_cast<int>(aRecordedCommandsAndSyncInstructions.size());
 		for (int i = 0; i < n; ++i) {
@@ -8038,7 +8130,13 @@ namespace avk
 			mCommandBufferToRecordInto.get().begin_recording();
 		}
 
-		record_into_command_buffer(mCommandBufferToRecordInto.get(), mRoot->dispatch_loader_ext(), aRecordedCommandsAndSyncInstructions);
+		record_into_command_buffer(mCommandBufferToRecordInto.get(), 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
+			mRoot->dispatch_loader_ext(),
+#else
+			mRoot->dispatch_loader_core(),
+#endif
+			aRecordedCommandsAndSyncInstructions);
 
 		if (aBeginEnd) {
 			mCommandBufferToRecordInto.get().end_recording();
@@ -8167,11 +8265,19 @@ namespace avk
 						.setClearValueCount(static_cast<uint32_t>(lClearValues.size()))
 						.setPClearValues(lClearValues.data());
 
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
 					cb.handle().beginRenderPass2KHR(
 						renderPassBeginInfo,
 						vk::SubpassBeginInfo{ aSubpassesInline ? vk::SubpassContents::eInline : vk::SubpassContents::eSecondaryCommandBuffers },
 						lRoot->dispatch_loader_ext()
 					);
+#else
+					cb.handle().beginRenderPass2(
+						renderPassBeginInfo,
+						vk::SubpassBeginInfo{ aSubpassesInline ? vk::SubpassContents::eInline : vk::SubpassContents::eSecondaryCommandBuffers },
+						lRoot->dispatch_loader_core()
+					);
+#endif
 				}
 			};
 		}
@@ -8192,7 +8298,11 @@ namespace avk
 				},
 				{},
 				[](avk::command_buffer_t& cb) {
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
 					cb.handle().endRenderPass2KHR(vk::SubpassEndInfo{}, cb.root_ptr()->dispatch_loader_ext());
+#else
+					cb.handle().endRenderPass2(vk::SubpassEndInfo{}, cb.root_ptr()->dispatch_loader_core());
+#endif
 				}
 			};
 		}
@@ -8226,11 +8336,19 @@ namespace avk
 			return action_type_command{
 				{}, {}, // Sync hints not applicable here, I guess
 				[aSubpassesInline](avk::command_buffer_t& cb) {
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
 					cb.handle().nextSubpass2KHR(
 						vk::SubpassBeginInfo{ aSubpassesInline ? vk::SubpassContents::eInline : vk::SubpassContents::eSecondaryCommandBuffers },
 						vk::SubpassEndInfo{},
 						cb.root_ptr()->dispatch_loader_ext()
 					);
+#else
+					cb.handle().nextSubpass2(
+						vk::SubpassBeginInfo{ aSubpassesInline ? vk::SubpassContents::eInline : vk::SubpassContents::eSecondaryCommandBuffers },
+						vk::SubpassEndInfo{},
+						cb.root_ptr()->dispatch_loader_core()
+					);
+#endif
 				}
 			};
 		}
@@ -8557,7 +8675,11 @@ namespace avk
 			.setPSignalSemaphoreInfos(signalSem.data());
 
 		auto fenceHandle = mFence.has_value() ? mFence.value()->handle() : vk::Fence{};
+#ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
 		auto result = mQueueToSubmitTo->handle().submit2KHR(1u, &submitInfo, fenceHandle, mRoot->dispatch_loader_ext());
+#else
+		auto result = mQueueToSubmitTo->handle().submit2(1u, &submitInfo, fenceHandle, mRoot->dispatch_loader_core());
+#endif
 
 		++mSubmissionCount;
 	}

--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -8676,9 +8676,15 @@ namespace avk
 
 		auto fenceHandle = mFence.has_value() ? mFence.value()->handle() : vk::Fence{};
 #ifdef AVK_USE_SYNCHRONIZATION2_INSTEAD_OF_CORE
-		auto result = mQueueToSubmitTo->handle().submit2KHR(1u, &submitInfo, fenceHandle, mRoot->dispatch_loader_ext());
+		auto errorCode = mQueueToSubmitTo->handle().submit2KHR(1u, &submitInfo, fenceHandle, mRoot->dispatch_loader_ext());
+		if (vk::Result::eSuccess != errorCode) {
+			AVK_LOG_WARNING("submit2KHR returned " + vk::to_string(errorCode));
+	    }
 #else
-		auto result = mQueueToSubmitTo->handle().submit2(1u, &submitInfo, fenceHandle, mRoot->dispatch_loader_core());
+		auto errorCode = mQueueToSubmitTo->handle().submit2(1u, &submitInfo, fenceHandle, mRoot->dispatch_loader_core());
+		if (vk::Result::eSuccess != errorCode) {
+			AVK_LOG_WARNING("submit2 returned " + vk::to_string(errorCode));
+		}
 #endif
 
 		++mSubmissionCount;


### PR DESCRIPTION
Added the preprocessor option `AVK_USE_CORE_INSTEAD_OF_SYNCHRONIZATION2`, which can be used to switch between using the 2KHR-type Vulkan API functions (from Synchronization2) or the 2-type Vulkan API functions (from core).

Usage is described under section `## Preprocessor Settings` in the main `README.md`.