### PR TITLE
Dynamic color attachment not registering correctly in graphics pipeline creation

### DIFF
--- a/src/avk.cpp
+++ b/src/avk.cpp
@@ -4858,7 +4858,7 @@ namespace avk
 					depth_attachments.push_back(dynamicRenderingAttachment.format());
 				} else if (is_stencil_format(dynamicRenderingAttachment.format())) {
 					stencil_attachments.push_back(dynamicRenderingAttachment.format());
-				} else if (!dynamicRenderingAttachment.mSubpassUsages.get_subpass_usage(0).as_color()) {
+				} else if (dynamicRenderingAttachment.mSubpassUsages.get_subpass_usage(0).as_color()) {
 					result.mDynamicRenderingColorFormats.push_back(dynamicRenderingAttachment.format());
 				}
 			}


### PR DESCRIPTION
**[Description]** This PR fixes an issue in which color attachments were failing to register in mDynamicRenderingColorFormats due to an incorrect logic negation in src/avk.cpp.

**[Issue Summary]** In the previous implementation, the condition to push back a format was ! ... as_color(). This meant the format was only added if the attachment was not marked as a color attachment. As a result, valid color attachments were being ignored during pipeline creation.

```cpp
// 15. Set Rendering info if dynamic rendering is enabled
if(dynamicRenderingEnabled)
{
	std::vector<vk::Format> depth_attachments;
	std::vector<vk::Format> stencil_attachments;
	for(const auto & dynamicRenderingAttachment : aConfig.mDynamicRenderingAttachments.value())
	{
		if(is_depth_format(dynamicRenderingAttachment.format())) {
			depth_attachments.push_back(dynamicRenderingAttachment.format());
		} else if (is_stencil_format(dynamicRenderingAttachment.format())) {
			stencil_attachments.push_back(dynamicRenderingAttachment.format());
		} else if (!dynamicRenderingAttachment.mSubpassUsages.get_subpass_usage(0).as_color()) { // <<< This disallows color attachments to be registered correctly
			result.mDynamicRenderingColorFormats.push_back(dynamicRenderingAttachment.format());
		}
	}
	if(depth_attachments.size() > 1)   { throw avk::runtime_error("Provided multiple depth attachments! Only one is supported!"); }
	if(stencil_attachments.size() > 1) { throw avk::runtime_error("Provided multiple stencil attachments! Only one is supported!"); }

	result.mRenderingCreateInfo = vk::PipelineRenderingCreateInfoKHR{}
		.setColorAttachmentCount(static_cast<uint32_t>(result.mDynamicRenderingColorFormats.size()))
		.setPColorAttachmentFormats(result.mDynamicRenderingColorFormats.data())
		.setDepthAttachmentFormat(depth_attachments.size() == 1 ? depth_attachments.at(0) : vk::Format{})
		.setStencilAttachmentFormat(stencil_attachments.size() == 1 ? stencil_attachments.at(0) : vk::Format{});
}
```

**[Context]** I encountered this issue while implementing a lensflare shader using Auto-VK with dynamic rendering enabled. Despite correct alpha blending and buffer setup (confirmed by Renderdoc & Nvidia Nsight Graphics), the background remained black.

I am explicitly setting the format via avk::usage::color(i) as seen below:

```cpp
std::vector<avk::attachment> dyn_attachments;
for (uint32_t i = 0; i < color_formats.size(); ++i) {
    dyn_attachments.push_back(
        avk::attachment::declare(
            color_formats[i],
            (options.blending == "additive" || options.blending == "alpha") ? avk::on_load::load : avk::on_load::clear,
            avk::usage::color(i), // Explicitly setting as color
            avk::on_store::store
        )
    );
    
    config.mColorBlendingPerAttachment.push_back(blending_config);
}
```

which is then passed to the pipeline builder function (`create_graphics_pipeline`).

Reverting the negation resolves the rendering issue on my end.

